### PR TITLE
Updating README to be clearer about Ruby version, and linking to INSTALL_PREREQ

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -8,18 +8,21 @@ Hydra-Head is a Rails Engines plugin containing the core code for a Hydra applic
 - "OM (Opinionated Metadata)":https://github.com/mediashelf/om (a ruby gem) to streamline the metadata configuration
 - "Solrizer":https://github.com/projecthydra/solrizer (a ruby gem) to write content to the Solr index
 - "SolrizerFedora":https://github.com/projecthydra/solrizer-fedora (a ruby gem) to write Fedora content to the Solr index.
-- HydraHead (a rails engines plugin) to glue it all together 
+- Hydra-Head (a rails engines plugin) to glue it all together 
 
-For a more thorough overview of the Hydra framework, see "HYDRA_OVERVIEW.textile":https://github.com/projecthydra/hydrangea/blob/master/HYDRA_OVERVIEW.textile.
+For a more thorough overview of the Hydra framework, see "HYDRA_OVERVIEW.textile":https://github.com/projecthydra/hydrangea/blob/master/HYDRA_OVERVIEW.textile.  If you're looking to develop an application based on Hydra-Head, you might also be interested in "install prerequisites":https://github.com/projecthydra/hydra-head/blob/master/INSTALL_PREREQ.textile
 
 This is a Ruby on Rails 3 gem.
 
 h2. Installation/Setup
 
+h3. Ruby
+
+Currently all Hydra software uses Ruby 1.8.7 (and not 1.9). 
+
 h3. Install Rails, Bundler and Devise
 
-Currently hydra-head is compatible with Rails 3.0.x and incompatible with Rails 3.1. Currently all Hydra software is compatible with ruby 1.8.7 (and not 1.9)
-
+Currently hydra-head is compatible with Rails 3.0.x and incompatible with Rails 3.1.
 
 <pre>
 gem install 'rails' --version '~>3.0.11'


### PR DESCRIPTION
Linked to INSTALL_PREREQ for devs (not sure if this is the right doc), and moved Ruby version info into its own subsection for more visibility.
