### PR TITLE
hydra-575: adding status code tests, fixing 404 redirect behavior

### DIFF
--- a/lib/hydra/catalog.rb
+++ b/lib/hydra/catalog.rb
@@ -21,6 +21,7 @@ module Hydra::Catalog
     # View Helpers
     helper :hydra_uploader
     helper :article_metadata
+    rescue_from Blacklight::Exceptions::InvalidSolrID, :with => :nonexistent_document
   end
   
   def edit
@@ -33,5 +34,19 @@ module Hydra::Catalog
     show
     render "show"
   end
-
+  
+  def enforce_opensearch_permissions
+    return enforce_index_permissions
+  end
+  
+  def nonexistent_document
+    if Rails.env == "development"
+      render
+    else
+      flash[:notice] = "Sorry, you have requested a record that doesn't exist."
+      params.delete(:id)
+      index
+      render "index", :status => 404
+    end
+  end
 end

--- a/test_support/features/html_validity.feature
+++ b/test_support/features/html_validity.feature
@@ -21,8 +21,7 @@ Feature: HTML validity
   Scenario: Search Results (authenticated)
     Given I am logged in as "archivist1@example.com" 
     When I am on the home page
-    And I follow "Article"
-#This may fail if there are a lot of articles in fedora and the expected article is not on the first page
+    And I follow "TOPIC 1"
     Then I should see "TITLE OF HOST JOURNAL"
     And the page should be HTML5 valid
     

--- a/test_support/features/nonexistent_object_show.feature
+++ b/test_support/features/nonexistent_object_show.feature
@@ -1,0 +1,9 @@
+Feature: Non-existent Objects - Show View
+  I want to see a 404 for the show view for objects not in fedora or solr
+  Scenario: an object exists for an id
+    Given I am on the show document page for hydra:test_no_model
+    Then I should get a status code 200
+  Scenario: no object exists for an id 
+    Given I am on the show document page for hydra:test_no_exist
+    Then I should get a status code 404
+    And I should see "Sorry, you have requested a record that doesn't exist."

--- a/test_support/features/step_definitions/web_steps.rb
+++ b/test_support/features/step_definitions/web_steps.rb
@@ -217,3 +217,7 @@ end
 Then /^show me the page$/ do
   save_and_open_page
 end
+
+Then  /^I should get a status code (\d+)/ do |http_status|
+  page.driver.status_code.should == http_status.to_i
+end

--- a/test_support/spec/controllers/catalog_controller_spec.rb
+++ b/test_support/spec/controllers/catalog_controller_spec.rb
@@ -109,6 +109,7 @@ describe CatalogController do
     end
     describe "show" do
       it "should trigger enforce_show_permissions and load_fedora_document" do
+        controller.stubs(:current_user).returns(nil)
         controller.expects(:load_fedora_document)
         controller.expects(:enforce_show_permissions)
         get :show, :id=>'test:3'
@@ -116,6 +117,7 @@ describe CatalogController do
     end
     describe "edit" do
       it "should trigger enforce_edit_permissions and load_fedora_document" do
+        controller.stubs(:current_user).returns(nil)
         controller.expects(:load_fedora_document)
         controller.expects(:enforce_edit_permissions)
         get :edit, :id=>'test:3'


### PR DESCRIPTION
This branch might not be what you want, but it works around the blacklight bug that's keeping the 404s from working as expected.  Something to talk about tomorrow, anyway.

Also has an enforce_opensearch_permissions method on catalog, since I was seeing errors similar to HYDRA-769 in the tests. 
