### PR TITLE
Removed reference to folder_index_path

### DIFF
--- a/hydra-file-access/app/views/_user_util_links.html.erb
+++ b/hydra-file-access/app/views/_user_util_links.html.erb
@@ -19,6 +19,4 @@
 <% end %>
 
 | 
-<%= link_to "Selected Items", folder_index_path %> (<span id="folder_number"><%= "#{session[:folder_document_ids] ? session[:folder_document_ids].length : 0}" %></span>)
-|
 <%= link_to "Search History", search_history_path %>


### PR DESCRIPTION
Removed reference to folder_index_path, which is not supported by the latest Blacklight (or so I've been told).
