### PR TITLE
Index edit and read groups for access control enforcement 

### DIFF
--- a/hydra-access-controls/lib/hydra/datastream/rights_metadata.rb
+++ b/hydra-access-controls/lib/hydra/datastream/rights_metadata.rb
@@ -24,8 +24,8 @@ module Hydra
         t.access {
           t.human_readable(:path=>"human")
           t.machine {
-            t.group
-            t.person
+            t.group(:index_as=>[:searchable])
+            t.person(:index_as=>[:searchable])
           }
           t.person(:proxy=>[:machine, :person])
           t.group(:proxy=>[:machine, :group])


### PR DESCRIPTION
With OM only indexing explicitly marked as such, the read and edit groups/people weren't getting indexed and all access control checks failing as a result (for objects indexed under the new OM).
