### PR TITLE
Added test for hh failing with groups containing slashes

### DIFF
--- a/hydra-core/spec/controllers/catalog_controller_spec.rb
+++ b/hydra-core/spec/controllers/catalog_controller_spec.rb
@@ -65,6 +65,12 @@ describe CatalogController do
         get :index
         assigns(:document_list).count.should == @public_only_results.docs.count
       end
+
+      it "should return documents if user has groups" do
+        RoleMapper.stub(:roles).and_return(["abc/123","cde/567"])
+        get :index
+        assigns(:document_list).count.should == @public_only_results.docs.count
+      end
     end
   end
   


### PR DESCRIPTION
Included a new controller test that specifies groups containing slashes.
This test should find the same number of files as the public search since the groups do not exist, but no documents are returned instead.
Solr is not happy with the slashes being passed directly inthe grup names.
