### PR TITLE
Commented out ICUFoldingFilterFactory in the solr config as doesn't exist in Solr 4.

### DIFF
--- a/hydra-core/lib/generators/hydra/templates/solr_conf/conf/schema.xml
+++ b/hydra-core/lib/generators/hydra/templates/solr_conf/conf/schema.xml
@@ -200,7 +200,8 @@
      <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
        <analyzer>
          <tokenizer class="solr.StandardTokenizerFactory"/>
-         <filter class="solr.ICUFoldingFilterFactory" />
+         <!-- FIXME: ICUFoldingFactory doesn't exist in Solr 4.0. -->
+         <!-- <filter class="solr.ICUFoldingFilterFactory" /> -->
          <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
          <filter class="solr.SnowballPorterFilterFactory" language="English" />
        </analyzer>


### PR DESCRIPTION
Commented out ICUFoldingFilterFactory in the solr config as doesn't exist in Solr 4. Needed for the tutorial as otherwise it will copy the configs and the Solr cores will fail to start.
