### PR TITLE
Remove refrences to dictionaries that aren't in the default solrconfig

### DIFF
--- a/hydra-core/lib/generators/hydra/templates/catalog_controller.rb
+++ b/hydra-core/lib/generators/hydra/templates/catalog_controller.rb
@@ -118,9 +118,6 @@ class CatalogController < ApplicationController
     # of Solr search fields. 
     
     config.add_search_field('title') do |field|
-      # solr_parameters hash are sent to Solr as ordinary url query params. 
-      field.solr_parameters = { :'spellcheck.dictionary' => 'title' }
-
       # :solr_local_parameters will be sent using Solr LocalParams
       # syntax, as eg {! qf=$title_qf }. This is neccesary to use
       # Solr parameter de-referencing like $title_qf.
@@ -132,7 +129,6 @@ class CatalogController < ApplicationController
     end
     
     config.add_search_field('author') do |field|
-      field.solr_parameters = { :'spellcheck.dictionary' => 'author' }
       field.solr_local_parameters = { 
         :qf => '$author_qf',
         :pf => '$author_pf'
@@ -143,7 +139,6 @@ class CatalogController < ApplicationController
     # tests can test it. In this case it's the same as 
     # config[:default_solr_parameters][:qt], so isn't actually neccesary. 
     config.add_search_field('subject') do |field|
-      field.solr_parameters = { :'spellcheck.dictionary' => 'subject' }
       field.qt = 'search'
       field.solr_local_parameters = { 
         :qf => '$subject_qf',


### PR DESCRIPTION
If you try to use them you get an NPE from solr.
