### PR TITLE
Removed jetty config

### DIFF
--- a/hydra-core/lib/generators/hydra/head_generator.rb
+++ b/hydra-core/lib/generators/hydra/head_generator.rb
@@ -45,7 +45,6 @@ class HeadGenerator < Rails::Generators::Base
    
     # Fedora & Solr YAML files
     invoke('active_fedora:config')
-    copy_file "config/jetty.yml", "config/jetty.yml"
   end
   
   # Add Hydra behaviors to the user model

--- a/hydra-core/lib/generators/hydra/templates/config/jetty.yml
+++ b/hydra-core/lib/generators/hydra/templates/config/jetty.yml
@@ -1,5 +1,0 @@
-default:
-  jetty_port: 8983
-  java_opts:
-    - "-XX:MaxPermSize=128m" 
-    - "-Xmx256m"


### PR DESCRIPTION
Get from active fedora as updated in https://github.com/projecthydra/active_fedora/pull/30.
