### PR TITLE
allowing the ability to set the discovery_permissions

### DIFF
--- a/hydra-access-controls/lib/hydra/access_controls_enforcement.rb
+++ b/hydra-access-controls/lib/hydra/access_controls_enforcement.rb
@@ -89,9 +89,13 @@ module Hydra::AccessControlsEnforcement
 
   
   # Which permission levels (logical OR) will grant you the ability to discover documents in a search.
+
   # Override this method if you want it to be something other than the default
   def discovery_permissions
-    ["edit","discover","read"]
+    @discovery_permissions ||= ["edit","discover","read"]
+  end
+  def disocvery_permissions= (permissions)
+    @discovery_permissions = permissions
   end
 
   # Contrller before filter that sets up access-controlled lucene query in order to provide gated discovery behavior

--- a/hydra-access-controls/spec/unit/access_controls_enforcement_spec.rb
+++ b/hydra-access-controls/spec/unit/access_controls_enforcement_spec.rb
@@ -35,6 +35,14 @@ describe Hydra::AccessControlsEnforcement do
         @solr_parameters[:fq].first.should_not match(/registered/) 
       end
       it "Then I should not have individual or group permissions"
+      it "Should changed based on the discovery_perissions" do
+        @solr_parameters = {}
+        discovery_permissions = ["read","edit"]
+        subject.send(:apply_gated_discovery, @solr_parameters, @user_parameters)
+        ["edit","read"].each do |type|
+          @solr_parameters[:fq].first.should match(/#{type}_access_group_ssim\:public/)      
+        end
+      end
     end
     context "Given I am a registered user" do
       before do
@@ -60,6 +68,16 @@ describe Hydra::AccessControlsEnforcement do
       it "Then I should see assets that my groups have discover, read, or edit access to" do
         ["faculty", "africana-faculty"].each do |group_id|
           ["discover","edit","read"].each do |type|
+            @solr_parameters[:fq].first.should match(/#{type}_access_group_ssim\:#{group_id}/)      
+          end
+        end
+      end
+      it "Should changed based on the discovery_perissions" do
+        @solr_parameters = {}
+        discovery_permissions = ["read","edit"]
+        subject.send(:apply_gated_discovery, @solr_parameters, @user_parameters)
+        ["faculty", "africana-faculty"].each do |group_id|
+          ["edit","read"].each do |type|
             @solr_parameters[:fq].first.should match(/#{type}_access_group_ssim\:#{group_id}/)      
           end
         end


### PR DESCRIPTION
Looking for the ability to set and get the discover_permission without redefining the method like here:  https://github.com/psu-stewardship/hydra-collections/blob/master/lib/hydra/collections/selects_collections.rb#L26-L27

The use case:  
I am a user who wants to add a public document to my collection.
The system needs to find all collections I can edit
while in the Catalog controller looking at all public and read documents.
