### PR TITLE
Removing explicit embargo_release_date Solr field

### DIFF
--- a/hydra-access-controls/lib/hydra/datastream/rights_metadata.rb
+++ b/hydra-access-controls/lib/hydra/datastream/rights_metadata.rb
@@ -187,7 +187,10 @@ module Hydra
         vals = read_access.machine.person
         solr_doc[ActiveFedora::SolrService.solr_name('read_access_person', indexer)] = vals unless vals.empty?
 
-        ::Solrizer::Extractor.insert_solr_field_value(solr_doc, "embargo_release_date_dt", embargo_release_date(:format=>:solr_date)) if embargo_release_date
+        if embargo_release_date
+          embargo_release_date_solr_key_name = ActiveFedora::SolrService.solr_name("embargo_release_date", date_indexer)
+          ::Solrizer::Extractor.insert_solr_field_value(solr_doc, embargo_release_date_solr_key_name , embargo_release_date(:format=>:solr_date))
+        end
         solr_doc
       end
 

--- a/hydra-access-controls/spec/unit/rights_metadata_spec.rb
+++ b/hydra-access-controls/spec/unit/rights_metadata_spec.rb
@@ -54,18 +54,21 @@ describe Hydra::ModelMixins::RightsMetadata do
   end
 
   context "to_solr" do
+    let(:embargo_release_date) { "2010-12-01" }
     before do
+      subject.rightsMetadata.embargo_release_date = embargo_release_date
       subject.rightsMetadata.update_permissions("person"=>{"person1"=>"read","person2"=>"discover"}, "group"=>{'group-6' => 'read', "group-7"=>'read', 'group-8'=>'edit'})
     end
     it "should produce a solr document" do
       result = subject.rightsMetadata.to_solr
-      result.size.should == 4
+      result.size.should == 5
       ## Wrote the test in this way, because the implementation uses a hash, and the hash order is not deterministic (especially in ruby 1.8.7)
       result['read_access_group_ssim'].size.should == 2
       result['read_access_group_ssim'].should include('group-6', 'group-7')
       result['edit_access_group_ssim'].should == ['group-8']
       result['discover_access_person_ssim'].should == ['person2']
       result['read_access_person_ssim'].should == ['person1']
+      result['embargo_release_date_dtsi'].should == subject.rightsMetadata.embargo_release_date(:format => :solr_date)
     end
   end
 


### PR DESCRIPTION
Prior to this fix, storing a document with an embargo release date
would raise an error about a missing field - embargo_release_date_dt was
expected but was no longer defined.

Closes #54
