### PR TITLE
Updating hydra generator for rspec

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -55,13 +55,6 @@ First, add them to the "Gemfile":http://gembundler.com/gemfile.html of your appl
     gem 'sass-rails', '~> 3.2.3'
     gem 'jquery-rails'
   end
-
-  # You will probably want to use these to run the tests you write for your hydra head
-  # For testing with rspec
-  group :development, :test do
-    gem 'rspec-rails'
-    gem 'jettywrapper'
-  end
 </pre>
 
 To install all of the dependencies, run:

--- a/hydra-core/lib/generators/hydra/head_generator.rb
+++ b/hydra-core/lib/generators/hydra/head_generator.rb
@@ -24,6 +24,20 @@ class HeadGenerator < Rails::Generators::Base
   # Config Files & Initializers
   #
 
+  def inject_test_framework
+    application("\n" <<
+      "    config.generators do |g|\n" <<
+      "      g.test_framework :rspec, :spec => true\n" <<
+      "    end\n\n"
+    )
+
+    gem_group :development, :test do
+      gem "rspec-rails"
+      gem 'jettywrapper'
+    end
+
+  end
+
   # Copy all files in templates/config directory to host config
   def create_configuration_files
     copy_file "catalog_controller.rb", "app/controllers/catalog_controller.rb"


### PR DESCRIPTION
Updating the configuration to incorporate rspec into the generated
application.

Also adjusting the generator documentation to reflect that we can
automatically append the rspec-rails and jettywrapper gem in the
base application.
