### PR TITLE
Fixed name of #discovery_permissions= method of Hydra::AccessControlsEnforcement

### DIFF
--- a/hydra-access-controls/lib/hydra/access_controls_enforcement.rb
+++ b/hydra-access-controls/lib/hydra/access_controls_enforcement.rb
@@ -94,7 +94,7 @@ module Hydra::AccessControlsEnforcement
   def discovery_permissions
     @discovery_permissions ||= ["edit","discover","read"]
   end
-  def disocvery_permissions= (permissions)
+  def discovery_permissions= (permissions)
     @discovery_permissions = permissions
   end
 


### PR DESCRIPTION
Take 2 on making this change ...
