### PR TITLE
User creation in spec tests fixed to avoid mass-assigment of protected attributes

### DIFF
--- a/hydra-core/spec/controllers/downloads_controller_spec.rb
+++ b/hydra-core/spec/controllers/downloads_controller_spec.rb
@@ -15,7 +15,7 @@ describe DownloadsController do
 
   describe "with a file" do
     before do
-      @user = User.create!(email: 'email@example.com', password: 'password')
+      @user = User.new.tap {|u| u.email = 'email@example.com'; u.password = 'password'; u.save}
       @obj = ActiveFedora::Base.new
       @obj = ModsAsset.new
       @obj.label = "world.png"
@@ -132,7 +132,7 @@ describe DownloadsController do
     describe "when not logged in as reader" do
       describe "show" do
         before do
-          sign_in User.create!(email: 'email2@example.com', password: 'password')
+          sign_in User.new.tap {|u| u.email = 'email2@example.com'; u.password = 'password'; u.save}
         end
         it "should deny access" do
           lambda { get "show", :id =>@obj.pid }.should raise_error Hydra::AccessDenied

--- a/hydra-core/spec/models/user_spec.rb
+++ b/hydra-core/spec/models/user_spec.rb
@@ -4,7 +4,7 @@ describe User do
 
   describe "user_key" do
     before do
-      @user = User.new(:email=>"foo@example.com")
+      @user = User.new.tap {|u| u.email = "foo@example.com"}
       @user.stub(:username =>'foo')
     end
 


### PR DESCRIPTION
Travis build of PR #74 is failing on Rails3 due to mass-assignment security restrictions.  CI tests pass locally.
