### PR TITLE
Escape spaces in group names in solr query conditions

### DIFF
--- a/hydra-access-controls/lib/hydra/access_controls_enforcement.rb
+++ b/hydra-access-controls/lib/hydra/access_controls_enforcement.rb
@@ -118,7 +118,7 @@ module Hydra::AccessControlsEnforcement
   end
 
   def escape_filter(key, value)
-    [key, value.gsub('/', '\/')].join(':')
+    [key, value.gsub(/[ \/]/, ' ' => '\ ', '/' => '\/')].join(':')
   end
 
   def apply_individual_permissions(permission_types)

--- a/hydra-access-controls/lib/hydra/policy_aware_access_controls_enforcement.rb
+++ b/hydra-access-controls/lib/hydra/policy_aware_access_controls_enforcement.rb
@@ -33,28 +33,28 @@ module Hydra::PolicyAwareAccessControlsEnforcement
   end
   
   
-  def apply_policy_role_permissions(permission_types)
+  def apply_policy_role_permissions(permission_types = discovery_permissions)
       # for roles
       user_access_filters = []
       current_ability.user_groups.each_with_index do |role, i|
-        discovery_permissions.each do |type|
-          user_access_filters << ActiveFedora::SolrService.solr_name("inheritable_#{type}_access_group", Hydra::Datastream::RightsMetadata.indexer ) + ":#{role}"
+        permission_types.each do |type|
+          user_access_filters << escape_filter(ActiveFedora::SolrService.solr_name("inheritable_#{type}_access_group", Hydra::Datastream::RightsMetadata.indexer ), role)
         end
       end
       user_access_filters
   end
 
-  def apply_policy_individual_permissions(permission_types)
+  def apply_policy_individual_permissions(permission_types = discovery_permissions)
     # for individual person access
     user_access_filters = []
     if current_user
-      discovery_permissions.each do |type|
-        user_access_filters << ActiveFedora::SolrService.solr_name("inheritable_#{type}_access_person", Hydra::Datastream::RightsMetadata.indexer ) + ":#{current_user.user_key}"        
+      permission_types.each do |type|
+        user_access_filters << escape_filter(ActiveFedora::SolrService.solr_name("inheritable_#{type}_access_person", Hydra::Datastream::RightsMetadata.indexer ), current_user.user_key)
       end
     end
     user_access_filters
   end
-  
+
   # Returns the Model used for AdminPolicy objects.
   # You can set this by overriding this method or setting Hydra.config[:permissions][:policy_class]
   # Defults to Hydra::AdminPolicy

--- a/hydra-access-controls/spec/unit/access_controls_enforcement_spec.rb
+++ b/hydra-access-controls/spec/unit/access_controls_enforcement_spec.rb
@@ -140,6 +140,14 @@ describe Hydra::AccessControlsEnforcement do
         @solr_parameters[:fq].first.should match(/#{type}_access_group_ssim\:cde\\\/567/)        
       end
     end
+    it "should escape spaces in the group names" do
+      RoleMapper.stub(:roles).with(@stub_user.user_key).and_return(["abc 123","cd/e 567"])
+      subject.send(:apply_gated_discovery, @solr_parameters, @user_parameters)
+      ["discover","edit","read"].each do |type|
+        @solr_parameters[:fq].first.should match(/#{type}_access_group_ssim\:abc\\ 123/)
+        @solr_parameters[:fq].first.should match(/#{type}_access_group_ssim\:cd\\\/e\\ 567/)
+      end
+    end
   end
   
   describe "exclude_unwanted_models" do


### PR DESCRIPTION
If spaces in group names aren't escaped the solr query becomes invalid and solr throws a 400.  The PR fixes that in both the normal and policy-aware access controls enforcement.
