### PR TITLE
All policies should be applied to gated discovery when more than 10 are applicable

### DIFF
--- a/hydra-access-controls/lib/hydra/policy_aware_access_controls_enforcement.rb
+++ b/hydra-access-controls/lib/hydra/policy_aware_access_controls_enforcement.rb
@@ -27,7 +27,7 @@ module Hydra::PolicyAwareAccessControlsEnforcement
     # Grant access based on user id & role
     user_access_filters += apply_policy_role_permissions(discovery_permissions)
     user_access_filters += apply_policy_individual_permissions(discovery_permissions)
-    result = policy_class.find_with_conditions( user_access_filters.join(" OR "), :fl => "id" )
+    result = policy_class.find_with_conditions( user_access_filters.join(" OR "), :fl => "id", :rows => policy_class.count )
     logger.debug "get policies: #{result}\n\n"
     result.map {|h| h['id']}
   end

--- a/hydra-access-controls/spec/unit/policy_aware_access_controls_enforcement_spec.rb
+++ b/hydra-access-controls/spec/unit/policy_aware_access_controls_enforcement_spec.rb
@@ -65,6 +65,14 @@ describe Hydra::PolicyAwareAccessControlsEnforcement do
     policy8.save
     @sample_policies << policy8
 
+    # user discover policies for testing that all are applied when over 10 are applicable
+    (9..11).each do |i|
+      policy = Hydra::AdminPolicy.create(:pid => "test:policy#{i}")
+      policy.default_permissions = [{:type=>"user", :access=>"discover", :name=>"sara_student"}]
+      policy.save
+      @sample_policies << policy
+    end
+
     # no access 
     policy_no_access = Hydra::AdminPolicy.create(:pid=>"test:policy_no_access")
     @sample_policies << policy_no_access


### PR DESCRIPTION
We ran into this where only the first ten policies associated with a user were applied to gated discovery leading to odd results.  Now the number of policy objects is used as the rows parameter to solr instead of leaving it to default to 10.
