### PR TITLE
Adds #asset_param_key method to DownloadBehavior

### DIFF
--- a/hydra-core/lib/hydra/controller/download_behavior.rb
+++ b/hydra-core/lib/hydra/controller/download_behavior.rb
@@ -14,15 +14,21 @@ module Hydra
           # we can now examine asset and determine if we should send_content, or some other action.
           send_content (asset)
         else 
-          logger.info "Can not read #{params['id']}"
-          raise Hydra::AccessDenied.new("You do not have sufficient access privileges to read this document, which has been marked private.", :read, params[:id])
+          logger.info "Can not read #{params[asset_param_key]}"
+          raise Hydra::AccessDenied.new("You do not have sufficient access privileges to read this document, which has been marked private.", :read, params[asset_param_key])
         end
       end
 
       protected
 
+      # Override this method if asset PID is not passed in params[:id],
+      # for example, in a nested resource.
+      def asset_param_key
+        :id
+      end
+
       def load_asset
-        @asset = ActiveFedora::Base.load_instance_from_solr(params[:id])
+        @asset = ActiveFedora::Base.load_instance_from_solr(params[asset_param_key])
       end
 
       def load_datastream

--- a/hydra-core/spec/controllers/downloads_controller_spec.rb
+++ b/hydra-core/spec/controllers/downloads_controller_spec.rb
@@ -139,5 +139,22 @@ describe DownloadsController do
         end
       end
     end
+
+    describe "overriding the default asset param key" do
+      before do
+        Rails.application.routes.draw do
+          scope 'objects/:object_id' do
+            get 'download' => 'downloads#show'
+          end
+        end
+        sign_in @user
+      end
+      it "should use the custom param value to retrieve the asset" do
+        controller.stub(:asset_param_key).and_return(:object_id)
+        get "show", :object_id => @obj.pid
+        response.should be_successful
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Supports overriding the default params key (:id) for the asset PID, for example, when using in a nested resource.

Supersedes closed/not merged PR https://github.com/projecthydra/hydra-head/pull/92.
