### PR TITLE
Added #permissions= as deprecated to maintain backward compatibility of ...

### DIFF
--- a/hydra-access-controls/app/models/concerns/hydra/access_controls/permissions.rb
+++ b/hydra-access-controls/app/models/concerns/hydra/access_controls/permissions.rb
@@ -2,12 +2,18 @@ module Hydra
   module AccessControls
     module Permissions
       extend ActiveSupport::Concern
+      extend Deprecation
       include Hydra::AccessControls::Visibility
 
       included do
         has_metadata "rightsMetadata", type: Hydra::Datastream::RightsMetadata
       end
 
+      # permissions= added for backward compatibility of Hydra::AdminPolicy for hydra-head < 6.4
+      def permissions= attributes_collection
+        Deprecation.warn(Permissions, "The permissions= method is deprecated and will be removed from Hydra::AccessControls::Permissions in hydra-head 7.0", caller)
+        self.permissions_attributes = attributes_collection
+      end
 
       ## Updates those permissions that are provided to it. Does not replace any permissions unless they are provided
       # @example

--- a/hydra-access-controls/lib/hydra/model_mixins/rights_metadata.rb
+++ b/hydra-access-controls/lib/hydra/model_mixins/rights_metadata.rb
@@ -9,29 +9,6 @@ module Hydra
         Deprecation.warn(RightsMetadata, "Hydra::ModelMixins::RightsMetadata has been deprecated and will be removed in hydra-head 7.0. Use Hydra::AccessControls::Permissions instead", caller(3));
       end
 
-
-
-      ## Updates those permissions that are provided to it. Does not replace any permissions unless they are provided
-      # @example
-      #  obj.permissions= [{:name=>"group1", :access=>"discover", :type=>'group'},
-      #  {:name=>"group2", :access=>"discover", :type=>'group'}]
-      def permissions=(params)
-        perm_hash = {'person' => rightsMetadata.individuals, 'group'=> rightsMetadata.groups}
-
-        params.each do |row|
-          if row[:type] == 'user' || row[:type] == 'person'
-            perm_hash['person'][row[:name]] = row[:access]
-          elsif row[:type] == 'group'
-            perm_hash['group'][row[:name]] = row[:access]
-          else
-            raise ArgumentError, "Permission type must be 'user', 'person' (alias for 'user'), or 'group'"
-          end
-        end
-        
-        rightsMetadata.update_permissions(perm_hash)
-      end
-
-
       ## Returns a list with all the permissions on the object.
       # @example
       #  [{:name=>"group1", :access=>"discover", :type=>'group'},

--- a/hydra-access-controls/spec/unit/permissions_spec.rb
+++ b/hydra-access-controls/spec/unit/permissions_spec.rb
@@ -111,4 +111,13 @@ describe Hydra::AccessControls::Permissions do
       subject.rightsMetadata.individuals.should == {"person1"=>"read","person2"=>"discover"}
     end
   end
+  describe "#permissions=" do
+    it "should behave like #permissions_attributes=" do
+      foo1 = Foo.new
+      foo2 = Foo.new
+      foo1.permissions = [{type: "user", access: "edit", name: "editor"}]
+      foo2.permissions_attributes = [{type: "user", access: "edit", name: "editor"}]
+      foo1.permissions.should == foo2.permissions
+    end
+  end
 end


### PR DESCRIPTION
...Hydra::AdminPolicy with hydra-head < 6.4.

(In hydra-head < 6.4 Hydra::AdminPolicy included Hydra::ModelMixins::RightsMetadata, which provided #permissions=.)
