### PR TITLE
Amended Hydra::User#groups to pass self to RoleMapper.roles in order to avoid redundant user lookup.

### DIFF
--- a/hydra-access-controls/lib/hydra/user.rb
+++ b/hydra-access-controls/lib/hydra/user.rb
@@ -15,7 +15,7 @@ module Hydra::User
   end
 
   def groups
-    RoleMapper.roles(user_key)
+    RoleMapper.roles(self)
   end
   
   module ClassMethods

--- a/hydra-access-controls/spec/unit/ability_spec.rb
+++ b/hydra-access-controls/spec/unit/ability_spec.rb
@@ -197,7 +197,7 @@ describe Ability do
     context "Then a collaborator with edit access (group permision)" do
       before do
         @user = FactoryGirl.build(:martia_morocco)
-        RoleMapper.stub(:roles).with(@user.user_key).and_return(@user.roles)
+        RoleMapper.stub(:roles).with(@user).and_return(@user.roles)
       end
       subject { Ability.new(@user) }
 
@@ -233,7 +233,7 @@ describe Ability do
     context "Then someone whose role/group has read access" do
       before do
         @user = FactoryGirl.build(:martia_morocco)
-        RoleMapper.stub(:roles).with(@user.user_key).and_return(@user.roles)
+        RoleMapper.stub(:roles).with(@user).and_return(@user.roles)
       end
       subject { Ability.new(@user) }
 

--- a/hydra-access-controls/spec/unit/access_controls_enforcement_spec.rb
+++ b/hydra-access-controls/spec/unit/access_controls_enforcement_spec.rb
@@ -88,7 +88,7 @@ describe Hydra::AccessControlsEnforcement do
   describe "enforce_show_permissions" do
     it "should allow a user w/ edit permissions to view an embargoed object" do
       user = User.new :uid=>'testuser@example.com'
-      RoleMapper.stub(:roles).with(user.user_key).and_return(["archivist"])
+      RoleMapper.stub(:roles).with(user).and_return(["archivist"])
       subject.stub(:current_user).and_return(user)
       subject.stub(:can?).with(:read, nil).and_return(true)
       stub_doc = Hydra::PermissionsSolrDocument.new({"edit_access_person_ssim"=>["testuser@example.com"], "embargo_release_date_dtsi"=>(Date.parse(Time.now.to_s)+2).to_s})
@@ -100,7 +100,7 @@ describe Hydra::AccessControlsEnforcement do
     end
     it "should prevent a user w/o edit permissions from viewing an embargoed object" do
       user = User.new :uid=>'testuser@example.com'
-      RoleMapper.stub(:roles).with(user.user_key).and_return([])
+      RoleMapper.stub(:roles).with(user).and_return([])
       subject.stub(:current_user).and_return(user)
       subject.stub(:can?).with(:read, nil).and_return(true)
       subject.params = {}
@@ -113,7 +113,7 @@ describe Hydra::AccessControlsEnforcement do
   describe "apply_gated_discovery" do
     before(:each) do
       @stub_user = User.new :uid=>'archivist1@example.com'
-      RoleMapper.stub(:roles).with(@stub_user.user_key).and_return(["archivist","researcher"])
+      RoleMapper.stub(:roles).with(@stub_user).and_return(["archivist","researcher"])
       subject.stub(:current_user).and_return(@stub_user)
       @solr_parameters = {}
       @user_parameters = {}
@@ -133,7 +133,7 @@ describe Hydra::AccessControlsEnforcement do
     end
 
     it "should escape slashes in the group names" do
-      RoleMapper.stub(:roles).with(@stub_user.user_key).and_return(["abc/123","cde/567"])
+      RoleMapper.stub(:roles).with(@stub_user).and_return(["abc/123","cde/567"])
       subject.send(:apply_gated_discovery, @solr_parameters, @user_parameters)
       ["discover","edit","read"].each do |type|
         @solr_parameters[:fq].first.should match(/#{type}_access_group_ssim\:abc\\\/123/)        
@@ -141,7 +141,7 @@ describe Hydra::AccessControlsEnforcement do
       end
     end
     it "should escape spaces in the group names" do
-      RoleMapper.stub(:roles).with(@stub_user.user_key).and_return(["abc 123","cd/e 567"])
+      RoleMapper.stub(:roles).with(@stub_user).and_return(["abc 123","cd/e 567"])
       subject.send(:apply_gated_discovery, @solr_parameters, @user_parameters)
       ["discover","edit","read"].each do |type|
         @solr_parameters[:fq].first.should match(/#{type}_access_group_ssim\:abc\\ 123/)

--- a/hydra-access-controls/spec/unit/admin_policy_spec.rb
+++ b/hydra-access-controls/spec/unit/admin_policy_spec.rb
@@ -127,7 +127,7 @@ describe Hydra::AdminPolicy do
   describe "When accessing assets with Policies associated" do
     before do
       @user = FactoryGirl.build(:martia_morocco)
-      RoleMapper.stub(:roles).with(@user.user_key).and_return(@user.roles)
+      RoleMapper.stub(:roles).with(@user).and_return(@user.roles)
     end
     before(:all) do
       class TestAbility

--- a/hydra-access-controls/spec/unit/policy_aware_access_controls_enforcement_spec.rb
+++ b/hydra-access-controls/spec/unit/policy_aware_access_controls_enforcement_spec.rb
@@ -95,7 +95,7 @@ describe Hydra::PolicyAwareAccessControlsEnforcement do
   describe "policies_with_access" do
     context "Authenticated user" do
       before do
-        RoleMapper.stub(:roles).with(@user.user_key).and_return(@user.roles)
+        RoleMapper.stub(:roles).with(@user).and_return(@user.roles)
         subject.stub(:current_user).and_return(@user)
       end
       it "should return the policies that provide discover permissions" do
@@ -120,7 +120,7 @@ describe Hydra::PolicyAwareAccessControlsEnforcement do
   
   describe "apply_gated_discovery" do
     before do
-      RoleMapper.stub(:roles).with(@user.user_key).and_return(@user.roles)
+      RoleMapper.stub(:roles).with(@user).and_return(@user.roles)
       subject.stub(:current_user).and_return(@user)
     end
     it "should include policy-aware query" do
@@ -140,7 +140,7 @@ describe Hydra::PolicyAwareAccessControlsEnforcement do
 
   describe "apply_policy_role_permissions" do
     it "should escape slashes in the group names" do
-      RoleMapper.stub(:roles).with(@user.user_key).and_return(["abc/123","cde/567"])
+      RoleMapper.stub(:roles).with(@user).and_return(["abc/123","cde/567"])
       subject.stub(:current_user).and_return(@user)
       user_access_filters = subject.apply_policy_role_permissions
       ["edit","discover","read"].each do |type|
@@ -149,7 +149,7 @@ describe Hydra::PolicyAwareAccessControlsEnforcement do
       end
     end
     it "should escape spaces in the group names" do
-      RoleMapper.stub(:roles).with(@user.user_key).and_return(["abc 123","cd/e 567"])
+      RoleMapper.stub(:roles).with(@user).and_return(["abc 123","cd/e 567"])
       subject.stub(:current_user).and_return(@user)
       user_access_filters = subject.apply_policy_role_permissions
       ["edit","discover","read"].each do |type|


### PR DESCRIPTION
Fixes #111.
