### PR TITLE
Factored out code from .roles that resolves the user and user_id from user_or_uid

### DIFF
--- a/hydra-access-controls/lib/hydra/role_mapper_behavior.rb
+++ b/hydra-access-controls/lib/hydra/role_mapper_behavior.rb
@@ -12,13 +12,7 @@ module Hydra::RoleMapperBehavior
     # @param user_or_uid either the User object or user id
     # If you pass in a nil User object (ie. user isn't logged in), or a uid that doesn't exist, it will return an empty array
     def roles(user_or_uid)
-      if user_or_uid.kind_of?(String)
-        user = Hydra::Ability.user_class.find_by_user_key(user_or_uid)
-        user_id = user_or_uid
-      elsif user_or_uid.kind_of?(Hydra::Ability.user_class) && user_or_uid.user_key   
-        user = user_or_uid
-        user_id = user.user_key
-      end
+      user, user_id = get_user_and_uid(user_or_uid)
       array = byname[user_id].dup || []
       array = array << 'registered' unless (user.nil? || user.new_record?) 
       array
@@ -40,6 +34,19 @@ module Hydra::RoleMapperBehavior
         ((usernames if usernames.respond_to?(:each)) || [usernames]).each { |x| memo[x]<<role}
         memo
       end
+    end
+
+    protected
+
+    def get_user_and_uid(user_or_uid)
+      if user_or_uid.kind_of?(String)
+        user = Hydra::Ability.user_class.find_by_user_key(user_or_uid)
+        user_id = user_or_uid
+      elsif user_or_uid.kind_of?(Hydra::Ability.user_class) && user_or_uid.user_key   
+        user = user_or_uid
+        user_id = user.user_key
+      end
+      [user, user_id]
     end
     
   end


### PR DESCRIPTION
This will allow modules overriding Hydra::RoleMapperBehavior to avoid repeating this resolution.
