### PR TITLE
Patches Hydra::AccessControlsEnforcement#escape_filter to support group/role names containing colons.

### DIFF
--- a/hydra-access-controls/lib/hydra/access_controls_enforcement.rb
+++ b/hydra-access-controls/lib/hydra/access_controls_enforcement.rb
@@ -118,7 +118,7 @@ module Hydra::AccessControlsEnforcement
   end
 
   def escape_filter(key, value)
-    [key, value.gsub(/[ \/]/, ' ' => '\ ', '/' => '\/')].join(':')
+    [key, value.gsub(/[ :\/]/, ' ' => '\ ', '/' => '\/', ':' => '\:')].join(':')
   end
 
   def apply_individual_permissions(permission_types)

--- a/hydra-access-controls/spec/unit/access_controls_enforcement_spec.rb
+++ b/hydra-access-controls/spec/unit/access_controls_enforcement_spec.rb
@@ -148,6 +148,14 @@ describe Hydra::AccessControlsEnforcement do
         @solr_parameters[:fq].first.should match(/#{type}_access_group_ssim\:cd\\\/e\\ 567/)
       end
     end
+    it "should escape colons in the group names" do
+      RoleMapper.stub(:roles).with(@stub_user).and_return(["abc:123","cde:567"])
+      subject.send(:apply_gated_discovery, @solr_parameters, @user_parameters)
+      ["discover","edit","read"].each do |type|
+        @solr_parameters[:fq].first.should match(/#{type}_access_group_ssim\:abc\\:123/)
+        @solr_parameters[:fq].first.should match(/#{type}_access_group_ssim\:cde\\:567/)
+      end
+    end
   end
   
   describe "exclude_unwanted_models" do


### PR DESCRIPTION
This is needed in particular to support Grouper, which uses colons as folder/name path separators.
