### PR TITLE
Changed method names to use "user" instead of "individual" or "person", and "group" instead of "role".

### DIFF
--- a/hydra-access-controls/app/models/concerns/hydra/access_controls/permissions.rb
+++ b/hydra-access-controls/app/models/concerns/hydra/access_controls/permissions.rb
@@ -20,7 +20,7 @@ module Hydra
       #  obj.permissions_attributes= [{:name=>"group1", :access=>"discover", :type=>'group'},
       #  {:name=>"group2", :access=>"discover", :type=>'group'}]
       def permissions_attributes= attributes_collection
-        perm_hash = {'person' => rightsMetadata.individuals, 'group'=> rightsMetadata.groups}
+        perm_hash = {'person' => rightsMetadata.users, 'group'=> rightsMetadata.groups}
 
         if attributes_collection.is_a? Hash
           attributes_collection = attributes_collection.sort_by { |i, _| i.to_i }.map { |_, attributes| attributes }
@@ -52,7 +52,7 @@ module Hydra
       ## Returns a list with all the permissions on the object.
       def permissions
         (rightsMetadata.groups.map {|x| Permission.new(type: 'group', access: x[1], name: x[0] )} + 
-          rightsMetadata.individuals.map {|x|  Permission.new(type: 'user', access: x[1], name: x[0] )})
+          rightsMetadata.users.map {|x|  Permission.new(type: 'user', access: x[1], name: x[0] )})
       end
 
       # Return a list of groups that have discover permission
@@ -107,7 +107,7 @@ module Hydra
       end
 
       def discover_users
-        rightsMetadata.individuals.map {|k, v| k if v == 'discover'}.compact
+        rightsMetadata.users.map {|k, v| k if v == 'discover'}.compact
       end
 
       # Grant discover permissions to the users specified. Revokes discover permission for all other users.
@@ -208,7 +208,7 @@ module Hydra
       end
 
       def read_users
-        rightsMetadata.individuals.map {|k, v| k if v == 'read'}.compact
+        rightsMetadata.users.map {|k, v| k if v == 'read'}.compact
       end
 
       # Grant read permissions to the users specified. Revokes read permission for all other users.
@@ -310,7 +310,7 @@ module Hydra
       end
 
       def edit_users
-        rightsMetadata.individuals.map {|k, v| k if v == 'edit'}.compact
+        rightsMetadata.users.map {|k, v| k if v == 'edit'}.compact
       end
 
       # Grant edit permissions to the groups specified. Revokes edit permission for all other groups.
@@ -350,8 +350,6 @@ module Hydra
       end
 
       private 
-
-
 
       # @param  permission either :discover, :read or :edit
       # @param  type either :person or :group

--- a/hydra-access-controls/lib/hydra/admin_policy.rb
+++ b/hydra-access-controls/lib/hydra/admin_policy.rb
@@ -48,7 +48,7 @@ class Hydra::AdminPolicy < ActiveFedora::Base
   #  obj.default_permissions= [{:name=>"group1", :access=>"discover", :type=>'group'},
   #  {:name=>"group2", :access=>"discover", :type=>'group'}]
   def default_permissions=(params)
-    perm_hash = {'person' => defaultRights.individuals, 'group'=> defaultRights.groups}
+    perm_hash = {'person' => defaultRights.users, 'group'=> defaultRights.groups}
 
     params.each do |row|
       if row[:type] == 'user' || row[:type] == 'person'
@@ -72,7 +72,7 @@ class Hydra::AdminPolicy < ActiveFedora::Base
   #  {:name=>"user3", :access=>"read", :type=>'user'}]
   def default_permissions
     (defaultRights.groups.map {|x| {:type=>'group', :access=>x[1], :name=>x[0] }} + 
-      defaultRights.individuals.map {|x| {:type=>'user', :access=>x[1], :name=>x[0]}})
+      defaultRights.users.map {|x| {:type=>'user', :access=>x[1], :name=>x[0]}})
 
   end
 

--- a/hydra-access-controls/lib/hydra/datastream/rights_metadata.rb
+++ b/hydra-access-controls/lib/hydra/datastream/rights_metadata.rb
@@ -3,6 +3,7 @@ module Hydra
   module Datastream
     # Implements Hydra RightsMetadata XML terminology for asserting access permissions
     class RightsMetadata < ActiveFedora::OmDatastream       
+      extend Deprecation
       
       set_terminology do |t|
         t.root(:path=>"rightsMetadata", :xmlns=>"http://hydra-collab.stanford.edu/schemas/rightsMetadata/v1", :schema=>"http://github.com/projecthydra/schemas/tree/v1/rightsMetadata.xsd") 
@@ -125,9 +126,14 @@ module Hydra
         return quick_search_by_type(:group)
       end
       
-      # Reports on which groups have which permissions
-      # @return Hash in format {person_name => person_permissions, person_name => person_permissions}
       def individuals
+        Deprecation.warn(RightsMetadata, "The method `individuals' is deprecated and will be removed from Hydra::Datastream::RightsMetadata in hydra-head 8.0.  Use `users' instead.", caller)
+        users
+      end
+
+      # Reports on which users have which permissions
+      # @return Hash in format {user_name => user_permissions, user_name => user_permissions}
+      def users
         return quick_search_by_type(:person)
       end
       
@@ -147,7 +153,7 @@ module Hydra
         group_ids = groups.keys | groups_for_update
         group_ids.each {|group_id| self.permissions({"group"=>group_id}, params['group'].fetch(group_id, 'none'))}
         users_for_update = params['person'] ? params['person'].keys : []
-        user_ids = individuals.keys | users_for_update
+        user_ids = users.keys | users_for_update
         user_ids.each {|person_id| self.permissions({"person"=>person_id}, params['person'].fetch(person_id, 'none'))}
       end
       

--- a/hydra-access-controls/lib/hydra/model_mixins/rights_metadata.rb
+++ b/hydra-access-controls/lib/hydra/model_mixins/rights_metadata.rb
@@ -18,7 +18,7 @@ module Hydra
       #  {:name=>"user3", :access=>"read", :type=>'user'}]
       def permissions
         (rightsMetadata.groups.map {|x| {:type=>'group', :access=>x[1], :name=>x[0] }} + 
-          rightsMetadata.individuals.map {|x| {:type=>'user', :access=>x[1], :name=>x[0]}})
+          rightsMetadata.users.map {|x| {:type=>'user', :access=>x[1], :name=>x[0]}})
 
       end
     

--- a/hydra-access-controls/lib/hydra/policy_aware_ability.rb
+++ b/hydra-access-controls/lib/hydra/policy_aware_ability.rb
@@ -99,7 +99,7 @@ module Hydra::PolicyAwareAbility
     edit_users_from_policy(policy_pid)
   end
 
-  # Returns the list of individuals granted edit access by the policy object identified by policy_pid
+  # Returns the list of users granted edit access by the policy object identified by policy_pid
   def edit_users_from_policy(policy_pid)
     policy_permissions = policy_permissions_doc(policy_pid)
     edit_user_field = Hydra.config[:permissions][:inheritable][:edit][:individual]
@@ -113,12 +113,12 @@ module Hydra::PolicyAwareAbility
     read_users_from_policy(policy_pid)
   end
 
-  # Returns the list of individuals granted read access by the policy object identified by policy_pid
+  # Returns the list of users granted read access by the policy object identified by policy_pid
   # Note: edit implies read, so read_users is the union of edit and read users
   def read_users_from_policy(policy_pid)
     policy_permissions = policy_permissions_doc(policy_pid)
-    read_individual_field = Hydra.config[:permissions][:inheritable][:read][:individual]
-    ru = edit_users_from_policy(policy_pid) | ((policy_permissions == nil || policy_permissions.fetch(read_individual_field,nil) == nil) ? [] : policy_permissions.fetch(read_individual_field,nil))
+    read_user_field = Hydra.config[:permissions][:inheritable][:read][:individual]
+    ru = edit_users_from_policy(policy_pid) | ((policy_permissions == nil || policy_permissions.fetch(read_user_field, nil) == nil) ? [] : policy_permissions.fetch(read_user_field, nil))
     logger.debug("[CANCAN] -policy- read_users: #{ru.inspect}")
     return ru
   end

--- a/hydra-access-controls/lib/hydra/policy_aware_access_controls_enforcement.rb
+++ b/hydra-access-controls/lib/hydra/policy_aware_access_controls_enforcement.rb
@@ -1,5 +1,6 @@
 # Repeats access controls evaluation methods, but checks against a governing "Policy" object (or "Collection" object) that provides inherited access controls.
 module Hydra::PolicyAwareAccessControlsEnforcement
+  extend Deprecation
   
   # Extends Hydra::AccessControlsEnforcement.apply_gated_discovery to reflect policy-provided access
   # appends the result of policy_clauses into the :fq
@@ -11,7 +12,6 @@ module Hydra::PolicyAwareAccessControlsEnforcement
     logger.debug("POLICY-aware Solr parameters: #{ solr_parameters.inspect }")
   end
 
-
   # returns solr query for finding all objects whose policies grant discover access to current_user
   def policy_clauses 
     policy_pids = policies_with_access
@@ -19,33 +19,41 @@ module Hydra::PolicyAwareAccessControlsEnforcement
     '(' + policy_pids.map {|pid| ActiveFedora::SolrService.construct_query_for_rel(is_governed_by: "info:fedora/#{pid}")}.join(' OR ') + ')'
   end
   
-  
-  # find all the policies that grant discover/read/edit permissions to this user or any of it's groups
+  # find all the policies that grant discover/read/edit permissions to this user or any of its groups
   def policies_with_access
     #### TODO -- Memoize this and put it in the session?
     user_access_filters = []
-    # Grant access based on user id & role
-    user_access_filters += apply_policy_role_permissions(discovery_permissions)
-    user_access_filters += apply_policy_individual_permissions(discovery_permissions)
+    # Grant access based on user id & group
+    user_access_filters += apply_policy_group_permissions(discovery_permissions)
+    user_access_filters += apply_policy_user_permissions(discovery_permissions)
     result = policy_class.find_with_conditions( user_access_filters.join(" OR "), :fl => "id", :rows => policy_class.count )
     logger.debug "get policies: #{result}\n\n"
     result.map {|h| h['id']}
   end
   
-  
   def apply_policy_role_permissions(permission_types = discovery_permissions)
-      # for roles
+    Deprecation.warn(Hydra::PolicyAwareAccessControlsEnforcement, "The method apply_policy_role_permissions is deprecated and will be removed from Hydra::PolicyAwareAccessControlsEnforcement in hydra-head 8.0.  Use apply_policy_group_permissions instead.", caller)
+    apply_policy_group_permissions(permission_types)
+  end
+
+  def apply_policy_group_permissions(permission_types = discovery_permissions)
+      # for groups
       user_access_filters = []
-      current_ability.user_groups.each_with_index do |role, i|
+      current_ability.user_groups.each_with_index do |group, i|
         permission_types.each do |type|
-          user_access_filters << escape_filter(ActiveFedora::SolrService.solr_name("inheritable_#{type}_access_group", Hydra::Datastream::RightsMetadata.indexer ), role)
+          user_access_filters << escape_filter(ActiveFedora::SolrService.solr_name("inheritable_#{type}_access_group", Hydra::Datastream::RightsMetadata.indexer ), group)
         end
       end
       user_access_filters
   end
 
   def apply_policy_individual_permissions(permission_types = discovery_permissions)
-    # for individual person access
+    Deprecation.warn(Hydra::PolicyAwareAccessControlsEnforcement, "The method apply_policy_individual_permissions is deprecated and will be removed from Hydra::PolicyAwareAccessControlsEnforcement in hydra-head 8.0.  Use apply_policy_user_permissions instead.", caller)
+    apply_policy_user_permissions(permission_types)
+  end
+
+  def apply_policy_user_permissions(permission_types = discovery_permissions)
+    # for individual user access
     user_access_filters = []
     if current_user
       permission_types.each do |type|

--- a/hydra-access-controls/spec/unit/access_controls_enforcement_spec.rb
+++ b/hydra-access-controls/spec/unit/access_controls_enforcement_spec.rb
@@ -171,14 +171,14 @@ describe Hydra::AccessControlsEnforcement do
     end
   end
 
-  describe "apply_individual_permissions" do
+  describe "apply_user_permissions" do
     describe "when the user is a guest user (user key nil)" do
       before do
         stub_user = User.new
         subject.stub(:current_user).and_return(stub_user)
       end
       it "should not create filters" do
-        subject.send(:apply_individual_permissions, ["edit","discover","read"]).should == []
+        subject.send(:apply_user_permissions, ["edit","discover","read"]).should == []
       end
     end
     describe "when the user is a guest user (user key empty string)" do
@@ -187,7 +187,7 @@ describe Hydra::AccessControlsEnforcement do
         subject.stub(:current_user).and_return(stub_user)
       end
       it "should not create filters" do
-        subject.send(:apply_individual_permissions, ["edit","discover","read"]).should == []
+        subject.send(:apply_user_permissions, ["edit","discover","read"]).should == []
       end
     end
   end


### PR DESCRIPTION
Deprecated legacy public methods - to be removed in hydra-head 8.0.

I intend to deal with the RoleMapper and Hydra config separately.
