### PR TITLE
Make RightsMetadata and InheritableRightsMetadata get Solr field names for #to_solr from Hydra config

### DIFF
--- a/hydra-access-controls/lib/hydra/datastream/inheritable_rights_metadata.rb
+++ b/hydra-access-controls/lib/hydra/datastream/inheritable_rights_metadata.rb
@@ -7,12 +7,10 @@ module Hydra
       @terminology = Hydra::Datastream::RightsMetadata.terminology
   
       def to_solr(solr_doc=Hash.new)
-        solr_doc[ActiveFedora::SolrService.solr_name('inheritable_discover_access_group', indexer)] = discover_access.machine.group
-        solr_doc[ActiveFedora::SolrService.solr_name('inheritable_discover_access_person', indexer)] = discover_access.machine.person
-        solr_doc[ActiveFedora::SolrService.solr_name('inheritable_read_access_group', indexer)] = read_access.machine.group
-        solr_doc[ActiveFedora::SolrService.solr_name('inheritable_read_access_person', indexer)] = read_access.machine.person
-        solr_doc[ActiveFedora::SolrService.solr_name('inheritable_edit_access_group', indexer)] = edit_access.machine.group
-        solr_doc[ActiveFedora::SolrService.solr_name('inheritable_edit_access_person', indexer)] = edit_access.machine.person
+        [:discover, :read, :edit].each do |access|
+          solr_doc[Hydra.config[:permissions][:inheritable][access][:group]] = send("#{access}_access").machine.group
+          solr_doc[Hydra.config[:permissions][:inheritable][access][:individual]] = send("#{access}_access").machine.person
+        end
         solr_doc[ActiveFedora::SolrService.solr_name('inheritable_embargo_release_date', date_indexer)] = embargo_release_date
         return solr_doc
       end

--- a/hydra-access-controls/lib/hydra/datastream/rights_metadata.rb
+++ b/hydra-access-controls/lib/hydra/datastream/rights_metadata.rb
@@ -195,19 +195,12 @@ module Hydra
 
       def to_solr(solr_doc=Hash.new)
         super(solr_doc)
-        vals = edit_access.machine.group
-        solr_doc[ActiveFedora::SolrService.solr_name('edit_access_group', indexer)] = vals unless vals.empty?
-        vals = discover_access.machine.group
-        solr_doc[ActiveFedora::SolrService.solr_name('discover_access_group', indexer)] = vals unless vals.empty?
-        vals = read_access.machine.group
-        solr_doc[ActiveFedora::SolrService.solr_name('read_access_group', indexer)] = vals unless vals.empty?
-        vals = edit_access.machine.person
-        solr_doc[ActiveFedora::SolrService.solr_name('edit_access_person', indexer)] = vals unless vals.empty?
-        vals = discover_access.machine.person
-        solr_doc[ActiveFedora::SolrService.solr_name('discover_access_person', indexer)] = vals unless vals.empty?
-        vals = read_access.machine.person
-        solr_doc[ActiveFedora::SolrService.solr_name('read_access_person', indexer)] = vals unless vals.empty?
-
+        [:discover, :read, :edit].each do |access|
+          vals = send("#{access}_access").machine.group
+          solr_doc[Hydra.config[:permissions][access][:group]] = vals unless vals.empty?
+          vals = send("#{access}_access").machine.person
+          solr_doc[Hydra.config[:permissions][access][:individual]] = vals unless vals.empty?
+        end
         if embargo_release_date
           embargo_release_date_solr_key_name = ActiveFedora::SolrService.solr_name("embargo_release_date", date_indexer)
           ::Solrizer::Extractor.insert_solr_field_value(solr_doc, embargo_release_date_solr_key_name , embargo_release_date(:format=>:solr_date))

--- a/hydra-access-controls/spec/spec_helper.rb
+++ b/hydra-access-controls/spec/spec_helper.rb
@@ -5,12 +5,42 @@ require 'rspec/autorun'
 require 'hydra-access-controls'
 
 module Hydra
-  # Stubbing Hydra.config[:policy_aware] so Hydra::PolicyAwareAbility will be loaded for tests.
   def self.config
-    {:permissions=>{:policy_aware => true}}
+    indexer = Solrizer::Descriptor.new(:string, :stored, :indexed, :multivalued)
+    {
+      :permissions => {
+        # Stubbing Hydra.config[:policy_aware] so Hydra::PolicyAwareAbility will be loaded for tests.
+        :policy_aware => true,
+        :discover => {
+          :group => ActiveFedora::SolrService.solr_name("discover_access_group", indexer), 
+          :individual => ActiveFedora::SolrService.solr_name("discover_access_person", indexer)
+        },
+        :read => {
+          :group => ActiveFedora::SolrService.solr_name("read_access_group", indexer), 
+          :individual => ActiveFedora::SolrService.solr_name("read_access_person", indexer)
+        },
+        :edit => {
+          :group => ActiveFedora::SolrService.solr_name("edit_access_group", indexer), 
+          :individual => ActiveFedora::SolrService.solr_name("edit_access_person", indexer)
+        },
+        :inheritable => {
+          :discover => {
+            :group => ActiveFedora::SolrService.solr_name("inheritable_discover_access_group", indexer), 
+            :individual => ActiveFedora::SolrService.solr_name("inheritable_discover_access_person", indexer)
+          },
+          :read => {
+            :group => ActiveFedora::SolrService.solr_name("inheritable_read_access_group", indexer), 
+            :individual => ActiveFedora::SolrService.solr_name("inheritable_read_access_person", indexer)
+          },
+          :edit => {
+            :group => ActiveFedora::SolrService.solr_name("inheritable_edit_access_group", indexer), 
+            :individual => ActiveFedora::SolrService.solr_name("inheritable_edit_access_person", indexer)
+          }
+        } # inheritable
+      }
+    }
   end
 end
-
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))


### PR DESCRIPTION
Make Hydra::Datastream::RightsMetadata#to_solr use Hydra config to get Solr field names.
Make Hydra::Datastream::InheritableRightsMetadata#to_solr use Hydra config to get Solr field names.
Added permissions and inherited permissions field names to stub Hydra config in hydra-access-controls spec_helper.
