### PR TITLE
Should be able to check :update and :destroy permissions with a SolrDoc

### DIFF
--- a/hydra-access-controls/lib/hydra/ability.rb
+++ b/hydra-access-controls/lib/hydra/ability.rb
@@ -67,7 +67,7 @@ module Hydra
         test_edit(obj.pid)
       end
    
-      can :edit, SolrDocument do |obj|
+      can [:edit, :update, :destroy], SolrDocument do |obj|
         cache.put(obj.id, obj)
         test_edit(obj.id)
       end       

--- a/hydra-access-controls/spec/support/solr_document.rb
+++ b/hydra-access-controls/spec/support/solr_document.rb
@@ -2,7 +2,12 @@ class SolrDocument
   def initialize(source_doc={}, solr_response=nil)
     @source_doc = source_doc
   end
-  def fetch(field, default)
+
+  def id
+    fetch(:id)
+  end
+
+  def fetch(field, default = nil)
     @source_doc[field]
   end
 


### PR DESCRIPTION
Previously only :edit was supported.
