### PR TITLE
ActiveFedora::Base#accessible_by relation to filter results based upon ability and action

### DIFF
--- a/hydra-access-controls/lib/active_fedora/accessible_by.rb
+++ b/hydra-access-controls/lib/active_fedora/accessible_by.rb
@@ -1,0 +1,20 @@
+ActiveFedora::Relation.class_eval do
+  include Hydra::AccessControlsEnforcement
+  def accessible_by(ability, action = :index)
+    return self if ability.blank?
+
+    permission_types = case action
+      when :index then [:discover, :read, :edit]
+      when :show, :read then [:read, :edit]
+      when :update, :edit, :create, :new, :destroy then [:edit]
+    end
+
+    relation = clone
+    relation.where_values = gated_discovery_filters(ability, permission_types).join(' OR ')
+    relation
+  end
+end
+
+ActiveFedora::Querying.module_eval do
+  delegate :accessible_by, :to=>:all
+end

--- a/hydra-access-controls/lib/hydra-access-controls.rb
+++ b/hydra-access-controls/lib/hydra-access-controls.rb
@@ -41,3 +41,5 @@ module Hydra
   # raised manually.
   class AccessDenied < ::CanCan::AccessDenied; end
 end
+
+require 'active_fedora/accessible_by'

--- a/hydra-access-controls/lib/hydra/access_controls_enforcement.rb
+++ b/hydra-access-controls/lib/hydra/access_controls_enforcement.rb
@@ -17,14 +17,12 @@ module Hydra::AccessControlsEnforcement
   
   protected
 
-  def gated_discovery_filters
-    # Grant access to public content
-    permission_types = discovery_permissions
+  def gated_discovery_filters(ability = current_ability, permission_types = discovery_permissions)
     user_access_filters = []
     
     # Grant access based on user id & group
     solr_access_filters_logic.each do |method_name|
-      user_access_filters += send(method_name, permission_types)
+      user_access_filters += send(method_name, permission_types, ability)
     end
     user_access_filters
   end
@@ -102,10 +100,10 @@ module Hydra::AccessControlsEnforcement
   end
 
   
-  def apply_group_permissions(permission_types)
+  def apply_group_permissions(permission_types, ability = current_ability)
       # for groups
       user_access_filters = []
-      current_ability.user_groups.each_with_index do |group, i|
+      ability.user_groups.each_with_index do |group, i|
         permission_types.each do |type|
           user_access_filters << escape_filter(ActiveFedora::SolrService.solr_name("#{type}_access_group", Hydra::Datastream::RightsMetadata.indexer), group)
         end
@@ -117,19 +115,20 @@ module Hydra::AccessControlsEnforcement
     [key, value.gsub(/[ :\/]/, ' ' => '\ ', '/' => '\/', ':' => '\:')].join(':')
   end
 
-  def apply_user_permissions(permission_types)
+  def apply_user_permissions(permission_types, ability = current_ability)
       # for individual user access
       user_access_filters = []
-      if current_user && current_user.user_key.present?
+      user = ability.current_user
+      if user && user.user_key.present?
         permission_types.each do |type|
-          user_access_filters << escape_filter(ActiveFedora::SolrService.solr_name("#{type}_access_person", Hydra::Datastream::RightsMetadata.indexer), current_user.user_key)
+          user_access_filters << escape_filter(ActiveFedora::SolrService.solr_name("#{type}_access_person", Hydra::Datastream::RightsMetadata.indexer), user.user_key)
         end
       end
       user_access_filters
   end
 
   # override to apply super user permissions
-  def apply_superuser_permissions(permission_types)
+  def apply_superuser_permissions(permission_types, ability = current_ability)
     []
   end
   

--- a/hydra-access-controls/spec/unit/accessible_by_spec.rb
+++ b/hydra-access-controls/spec/unit/accessible_by_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe "active_fedora/accessible_by" do
+  let(:user) {FactoryGirl.build(:ira_instructor)}
+  let(:ability) {Ability.new(user)}
+  let(:private_obj) {FactoryGirl.create(:default_access_asset)}
+  let(:public_obj) {FactoryGirl.create(:open_access_asset)}
+  let(:editable_obj) {FactoryGirl.create(:group_edit_asset)}
+
+  before do
+    user.should_receive(:groups).at_most(:once).and_return(user.roles)
+    ModsAsset.delete_all
+  end
+
+  after do
+    ModsAsset.delete_all
+  end
+
+  describe "#accsesible_by" do
+    it "should return objects readable by the ability" do
+      expect(ModsAsset.accessible_by(ability)).to eq [public_obj, editable_obj]
+    end
+    it "should return object editable by the ability" do
+      expect(ModsAsset.accessible_by(ability, :edit)).to eq [editable_obj]
+    end
+    it "should return only public objects for an anonymous user" do
+      expect(ModsAsset.accessible_by(Ability.new(nil))).to eq [public_obj]
+    end
+    pending "should apply to relationship relations"
+  end
+end


### PR DESCRIPTION
This method mirrors cancan's #accessible_by.  Fixes #141 
