### PR TITLE
Hydra::Admin policy updated to use has_attributes instead of deprecated ...

### DIFF
--- a/hydra-access-controls/hydra-access-controls.gemspec
+++ b/hydra-access-controls/hydra-access-controls.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_dependency 'activesupport'
-  gem.add_dependency "active-fedora", '~> 6.6'
+  gem.add_dependency "active-fedora", '~> 6.7'
   gem.add_dependency 'cancan'
   gem.add_dependency 'deprecation'
   gem.add_dependency 'blacklight', '~> 4.0' 

--- a/hydra-access-controls/lib/hydra/admin_policy.rb
+++ b/hydra-access-controls/lib/hydra/admin_policy.rb
@@ -14,10 +14,10 @@ class Hydra::AdminPolicy < ActiveFedora::Base
     
   end
 
-  delegate_to :descMetadata, [:title, :description], multiple: false
-  delegate :license_title, to: 'rightsMetadata', at: [:license, :title], multiple: false
-  delegate :license_description, to: 'rightsMetadata', at: [:license, :description], multiple: false
-  delegate :license_url, to: 'rightsMetadata', at: [:license, :url], multiple: false
+  has_attributes :title, :description, datastream: :descMetadata, multiple: false
+  has_attributes :license_title, datastream: 'rightsMetadata', at: [:license, :title], multiple: false
+  has_attributes :license_description, datastream: 'rightsMetadata', at: [:license, :description], multiple: false
+  has_attributes :license_url, datastream: 'rightsMetadata', at: [:license, :url], multiple: false
 
   # easy access to edit_groups, etc
   include Hydra::AccessControls::Permissions 


### PR DESCRIPTION
...delegate/delegate_to.

Require ActiveFedora ~> 6.7 in hydra-access-controls for #has_attributes
