### PR TITLE
Add sass-rails dependency

### DIFF
--- a/hydra-access-controls/hydra-access-controls.gemspec
+++ b/hydra-access-controls/hydra-access-controls.gemspec
@@ -24,6 +24,12 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'deprecation'
   gem.add_dependency "blacklight", '~> 5.0'
 
+  # sass-rails is typically generated into the app's gemfile by `rails new`
+  # In rails 3 it's put into the "assets" group and thus not available to the
+  # app. Blacklight 5.2 requires bootstrap-sass which requires (but does not
+  # declare a dependency on) sass-rails
+  gem.add_dependency 'sass-rails'
+
   gem.add_development_dependency "rake"
   gem.add_development_dependency 'rspec'
 


### PR DESCRIPTION
Blacklight 5.2 removed the sass-rails dependency, but we need it
loaded for rails 3.2.  Typically it's injected into the host app's
gemfile when doing `rails new`
