### PR TITLE
Adds ability to assert lease & embargo info including visibility_during ...

### DIFF
--- a/hydra-access-controls/app/models/concerns/hydra/access_controls.rb
+++ b/hydra-access-controls/app/models/concerns/hydra/access_controls.rb
@@ -3,6 +3,7 @@ module Hydra
     extend ActiveSupport::Autoload
     autoload :AccessRight
     autoload :WithAccessRight
+    autoload :Embargoable
     autoload :Visibility
     autoload :Permission
     autoload :Permissions

--- a/hydra-access-controls/app/models/concerns/hydra/access_controls/access_right.rb
+++ b/hydra-access-controls/app/models/concerns/hydra/access_controls/access_right.rb
@@ -8,6 +8,8 @@ module Hydra
       # The values that get drawn to the page
       VISIBILITY_TEXT_VALUE_PUBLIC = 'open'.freeze
       VISIBILITY_TEXT_VALUE_EMBARGO = 'open_with_embargo_release_date'.freeze
+      #VISIBILITY_TEXT_VALUE_EMBARGO = 'embargo'.freeze  # << !! Will change to this in next major release !!
+      VISIBILITY_TEXT_VALUE_LEASE = 'lease'.freeze
       VISIBILITY_TEXT_VALUE_AUTHENTICATED = 'authenticated'.freeze
       VISIBILITY_TEXT_VALUE_PRIVATE = 'restricted'.freeze
 

--- a/hydra-access-controls/app/models/concerns/hydra/access_controls/embargoable.rb
+++ b/hydra-access-controls/app/models/concerns/hydra/access_controls/embargoable.rb
@@ -1,0 +1,139 @@
+module Hydra
+  module AccessControls
+    module Embargoable
+      extend ActiveSupport::Concern
+      include Hydra::AccessControls::WithAccessRight
+
+      included do
+        validates :embargo_release_date, :'hydra/future_date' => true
+
+        has_attributes :visibility_during_embargo, :visibility_after_embargo, 
+          :visibility_during_lease, :visibility_after_lease, :lease_expiration_date,
+          :embargo_release_date,
+          datastream: 'rightsMetadata', multiple: false
+
+        has_attributes :embargo_history, :lease_history, datastream: 'rightsMetadata', multiple:true
+      end
+
+      def under_embargo?
+        @under_embargo ||= rightsMetadata.under_embargo?
+      end
+
+      def active_lease?
+        @active_lease ||= rightsMetadata.active_lease?
+      end
+
+      # If changing away from embargo or lease, this will deactivate the lease/embargo before proceeding.
+      # The lease_visibility! and embargo_visibility! methods rely on this to deactivate the lease when applicable.
+      def visibility=(value)
+        # If changing from embargo or lease, deactivate the lease/embargo and wipe out the associated metadata before proceeding
+        if !embargo_release_date.nil?
+          deactivate_embargo! unless value == visibility_during_embargo
+        end
+        if !lease_expiration_date.nil?
+          deactivate_lease! unless value == visibility_during_lease
+        end
+        super
+      end
+
+      def apply_embargo(release_date, visibility_during=nil, visibility_after=nil)
+        self.embargo_release_date = release_date
+        self.visibility_during_embargo = visibility_during unless visibility_during.nil?
+        self.visibility_after_embargo = visibility_after unless visibility_after.nil?
+        self.embargo_visibility!
+      end
+
+      def deactivate_embargo!
+        embargo_state = under_embargo? ? "active" : "expired"
+        embargo_record = "An #{embargo_state} embargo was deactivated on #{Date.today}.  Its release date was #{embargo_release_date}.  Visibility during embargo was #{visibility_during_embargo} and intended visibility after embargo was #{visibility_after_embargo}"
+        self.embargo_release_date = nil
+        self.visibility_during_embargo = nil
+        self.visibility_after_embargo = nil
+        self.embargo_history += [embargo_record]
+      end
+
+      def validate_embargo
+        if embargo_release_date
+          if under_embargo?
+            expected_visibility = visibility_during_embargo
+            failure_message = "An embargo is in effect for this object until #{embargo_release_date}.  Until that time the "
+          else
+            expected_visibility = visibility_after_embargo
+            failure_message = "The embargo expired on #{embargo_release_date}.  The "
+          end
+          if visibility == expected_visibility
+            return true
+          else
+            failure_message << "visibility should be #{expected_visibility} but it is currently #{visibility}.  Call embargo_visibility! on this object to repair."
+            self.errors[:embargo] << failure_message
+            return false
+          end
+        else
+          return true
+        end
+      end
+
+      def embargo_visibility!
+        if embargo_release_date
+          if under_embargo?
+            self.visibility_during_embargo = visibility_during_embargo ? visibility_during_embargo : Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+            self.visibility_after_embargo = visibility_after_embargo ? visibility_after_embargo : Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            self.visibility = visibility_during_embargo
+          else
+            self.visibility = visibility_after_embargo ? visibility_after_embargo : Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          end
+        end
+      end
+
+      def validate_lease
+        if lease_expiration_date
+          if active_lease?
+            expected_visibility = visibility_during_lease
+            failure_message = "A lease is in effect for this object until #{lease_expiration_date}.  Until that time the "
+          else
+            expected_visibility = visibility_after_lease
+            failure_message = "The lease expired on #{lease_expiration_date}.  The "
+          end
+          if visibility == expected_visibility
+            return true
+          else
+            failure_message << "visibility should be #{expected_visibility} but it is currently #{visibility}.  Call lease_visibility! on this object to repair."
+            self.errors[:lease] << failure_message
+            return false
+          end
+        else
+          return true
+        end
+      end
+
+      def apply_lease(release_date, visibility_during=nil, visibility_after=nil)
+        self.lease_expiration_date = release_date
+        self.visibility_during_lease = visibility_during unless visibility_during.nil?
+        self.visibility_after_lease = visibility_after unless visibility_after.nil?
+        self.lease_visibility!
+      end
+
+      def deactivate_lease!
+        lease_state = active_lease? ? "active" : "expired"
+        lease_record = "An #{lease_state} lease was deactivated on #{Date.today}.  Its release date was #{lease_expiration_date}.  Visibility during the lease was #{visibility_during_lease} and intended visibility after lease was #{visibility_after_lease}."
+        self.lease_expiration_date = nil
+        self.visibility_during_lease = nil
+        self.visibility_after_lease = nil
+        self.lease_history += [lease_record]
+      end
+
+      def lease_visibility!
+        if lease_expiration_date
+          if active_lease?
+            self.visibility_during_lease = visibility_during_lease ? visibility_during_lease : Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+            self.visibility_after_lease = visibility_after_lease ? visibility_after_lease : Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+            self.visibility = visibility_during_lease
+          else
+            self.visibility = visibility_after_lease ? visibility_after_lease : Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/hydra-access-controls/app/models/concerns/hydra/access_controls/with_access_right.rb
+++ b/hydra-access-controls/app/models/concerns/hydra/access_controls/with_access_right.rb
@@ -2,10 +2,7 @@ module Hydra
   module AccessControls
     module WithAccessRight
       extend ActiveSupport::Concern
-
-      def under_embargo?
-        @under_embargo ||= rightsMetadata.under_embargo?
-      end
+      include Hydra::AccessControls::Permissions
 
       delegate :open_access?, :open_access_with_embargo_release_date?, 
                :authenticated_only_access?, :private_access?, to: :access_rights

--- a/hydra-access-controls/app/services/hydra/embargo_service.rb
+++ b/hydra-access-controls/app/services/hydra/embargo_service.rb
@@ -1,0 +1,26 @@
+module Hydra
+  module EmbargoService
+    class << self
+      #
+      # Methods for Querying Repository to find Embargoed Objects
+      #
+
+      # Returns all assets with embargo release date set to a date in the past
+      def assets_with_expired_embargoes
+        ActiveFedora::Base.where("#{Hydra.config.permissions.embargo.release_date}:[* TO NOW]")
+      end
+
+      # Returns all assets with embargo release date set
+      #   (assumes that when lease visibility is applied to assets
+      #    whose leases have expired, the lease expiration date will be removed from its metadata)
+      def assets_under_embargo
+        ActiveFedora::Base.where("#{Hydra.config.permissions.embargo.release_date}:*")
+      end
+
+      # Returns all assets that have had embargoes deactivated in the past.
+      def assets_with_deactivated_embargoes
+        ActiveFedora::Base.where("#{Hydra.config.permissions.embargo.history}:*")
+      end
+    end
+  end
+end

--- a/hydra-access-controls/app/services/hydra/lease_service.rb
+++ b/hydra-access-controls/app/services/hydra/lease_service.rb
@@ -1,0 +1,23 @@
+module Hydra
+  module LeaseService
+    class << self
+      # Returns all assets with lease expiration date set to a date in the past
+      def assets_with_expired_leases
+        ActiveFedora::Base.where("#{Hydra.config.permissions.lease.expiration_date}:[* TO NOW]")
+      end
+
+      # Returns all assets with lease expiration date set
+      #   (assumes that when lease visibility is applied to assets
+      #    whose leases have expired, the lease expiration date will be removed from its metadata)
+      def assets_under_lease
+        ActiveFedora::Base.where("#{Hydra.config.permissions.lease.expiration_date}:*")
+      end
+
+      # Returns all assets that have had embargoes deactivated in the past.
+      def assets_with_deactivated_leases
+        ActiveFedora::Base.where("#{Hydra.config.permissions.lease.history}:*")
+      end
+    end
+  end
+end
+

--- a/hydra-access-controls/app/validators/hydra/future_date_validator.rb
+++ b/hydra-access-controls/app/validators/hydra/future_date_validator.rb
@@ -1,0 +1,20 @@
+module Hydra
+  class FutureDateValidator < ActiveModel::EachValidator
+
+    def validate_each(record, attribute, value)
+      if value.present?
+        begin
+          if date = value.to_date
+            if date <= Date.today
+              record.errors[:embargo_release_date] << "Must be a future date"
+            end
+          else
+            record.errors[:embargo_release_date] << "Invalid Date Format"
+          end
+        rescue ArgumentError, NoMethodError
+          record.errors[:embargo_release_date] << "Invalid Date Format"
+        end
+      end
+    end
+  end
+end

--- a/hydra-access-controls/lib/hydra/datastream/inheritable_rights_metadata.rb
+++ b/hydra-access-controls/lib/hydra/datastream/inheritable_rights_metadata.rb
@@ -11,7 +11,10 @@ module Hydra
           solr_doc[Hydra.config[:permissions][:inheritable][access][:group]] = send("#{access}_access").machine.group
           solr_doc[Hydra.config[:permissions][:inheritable][access][:individual]] = send("#{access}_access").machine.person
         end
-        solr_doc[Hydra.config[:permissions][:inheritable][:embargo_release_date]] = embargo_release_date
+        if embargo_release_date.present?
+          key = Hydra.config.permissions.inheritable.embargo.release_date.sub(/_[^_]+$/, '') #Strip off the suffix
+          ::Solrizer.insert_field(solr_doc, key, embargo_release_date, :stored_sortable)
+        end
         return solr_doc
       end
     end

--- a/hydra-access-controls/spec/services/embargo_service_spec.rb
+++ b/hydra-access-controls/spec/services/embargo_service_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Hydra::EmbargoService do
+  let(:future_date) { 2.days.from_now }
+  let(:past_date) { 2.days.ago }
+
+  let!(:work_with_expired_embargo1) do
+    FactoryGirl.build(:asset, embargo_release_date: past_date.to_s).tap do |work|
+      work.save(validate:false)
+    end
+  end
+
+  let!(:work_with_expired_embargo2) do
+    FactoryGirl.build(:asset, embargo_release_date: past_date.to_s).tap do |work|
+      work.save(validate:false)
+    end
+  end
+
+  let!(:work_with_embargo_in_effect) { FactoryGirl.create(:asset, embargo_release_date: future_date.to_s)}
+  let!(:work_without_embargo) { FactoryGirl.create(:asset)}
+
+  describe "#assets_with_expired_embargoes" do
+    it "returns an array of assets with expired embargoes" do
+      returned_pids = subject.assets_with_expired_embargoes.map {|a| a.pid}
+      expect(returned_pids).to include work_with_expired_embargo1.pid,work_with_expired_embargo2.pid
+      expect(returned_pids).to_not include work_with_embargo_in_effect.pid,work_without_embargo.pid
+    end
+  end
+
+  describe "#assets_under_embargo" do
+    it "returns all assets with embargo release date set" do
+      result = subject.assets_under_embargo
+      returned_pids = subject.assets_under_embargo.map {|a| a.pid}
+      expect(returned_pids).to include work_with_expired_embargo1.pid,work_with_expired_embargo2.pid,work_with_embargo_in_effect.pid
+      expect(returned_pids).to_not include work_without_embargo.pid
+    end
+  end
+end

--- a/hydra-access-controls/spec/services/lease_service_spec.rb
+++ b/hydra-access-controls/spec/services/lease_service_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Hydra::LeaseService do
+  let(:future_date) { 2.days.from_now }
+  let(:past_date) { 2.days.ago }
+
+  let!(:work_with_expired_lease1) do
+    FactoryGirl.build(:asset, lease_expiration_date: past_date.to_s).tap do |work|
+      work.save(validate: false)
+    end
+  end
+
+  let!(:work_with_expired_lease2) do
+    FactoryGirl.build(:asset, lease_expiration_date: past_date.to_s).tap do |work|
+      work.save(validate: false)
+    end
+  end
+
+  let!(:work_with_lease_in_effect) { FactoryGirl.create(:asset, lease_expiration_date: future_date.to_s)}
+  let!(:work_without_lease) { FactoryGirl.create(:asset)}
+
+  describe "#assets_with_expired_leases" do
+    it "returns an array of assets with expired embargoes" do
+      returned_pids = subject.assets_with_expired_leases.map {|a| a.pid}
+      expect(returned_pids).to include work_with_expired_lease1.pid,work_with_expired_lease2.pid
+      expect(returned_pids).to_not include work_with_lease_in_effect.pid,work_without_lease.pid
+    end
+  end
+
+  describe "#assets_under_lease" do
+    it "returns an array of assets with expired embargoes" do
+      returned_pids = subject.assets_under_lease.map {|a| a.pid}
+      expect(returned_pids).to include work_with_expired_lease1.pid,work_with_expired_lease2.pid,work_with_lease_in_effect.pid
+      expect(returned_pids).to_not include work_without_lease.pid
+    end
+  end
+end

--- a/hydra-access-controls/spec/spec_helper.rb
+++ b/hydra-access-controls/spec/spec_helper.rb
@@ -16,11 +16,6 @@ if ENV['COVERAGE'] and RUBY_VERSION =~ /^1.9/
   SimpleCov.start
 end
 
-require 'support/mods_asset'
-require 'support/solr_document'
-require "support/user"
-require "factory_girl"
-require "factories"
 
 require 'support/rails'
 Object.logger = Logger.new(File.expand_path('../test.log', __FILE__))
@@ -28,16 +23,18 @@ Object.logger = Logger.new(File.expand_path('../test.log', __FILE__))
 # Since we're not doing a Rails Engine test, we have to load these classes manually:
 require_relative '../app/models/role_mapper'
 require_relative '../app/models/ability'
-
+require_relative '../app/services/hydra/lease_service'
+require_relative '../app/services/hydra/embargo_service'
+require_relative '../app/validators/hydra/future_date_validator'
+require 'support/mods_asset'
+require 'support/solr_document'
+require "support/user"
+require "factory_girl"
+require "factories"
 
 
 RSpec.configure do |config|
 
-end
-
-# Stubbing a deprecated class/method so it won't mess up tests.
-class Hydra::SuperuserAttributes
- cattr_accessor :silenced
 end
 
 # Stubbing Devise

--- a/hydra-access-controls/spec/support/mods_asset.rb
+++ b/hydra-access-controls/spec/support/mods_asset.rb
@@ -1,8 +1,7 @@
-require 'active-fedora'
 class ModsAsset < ActiveFedora::Base
-  include Hydra::AccessControls::Permissions
+  include Hydra::AccessControls::Embargoable
   
   # This is how we're associating admin policies with assets.  
   # You can associate them however you want, just use the :is_governed_by relationship
-  belongs_to :admin_policy, :class_name=> "Hydra::AdminPolicy", :property=>:is_governed_by
+  belongs_to :admin_policy, class_name: "Hydra::AdminPolicy", property: :is_governed_by
 end

--- a/hydra-access-controls/spec/unit/access_controls_enforcement_spec.rb
+++ b/hydra-access-controls/spec/unit/access_controls_enforcement_spec.rb
@@ -94,7 +94,7 @@ describe Hydra::AccessControlsEnforcement do
       subject.params = {}
       subject.should_receive(:can?).with(:edit, stub_doc).and_return(true)
       subject.current_ability.should_receive(:get_permissions_solr_response_for_doc_id).and_return(stub_doc)
-      lambda {subject.send(:enforce_show_permissions, {}) }.should_not raise_error Hydra::AccessDenied
+      expect {subject.send(:enforce_show_permissions, {}) }.not_to raise_error Hydra::AccessDenied
     end
     it "should prevent a user w/o edit permissions from viewing an embargoed object" do
       user = User.new :uid=>'testuser@example.com'

--- a/hydra-access-controls/spec/unit/admin_policy_spec.rb
+++ b/hydra-access-controls/spec/unit/admin_policy_spec.rb
@@ -98,7 +98,7 @@ describe Hydra::AdminPolicy do
         subject[inheritable_group].should include("africana-faculty", "cool-kids")
 
         subject[Hydra.config[:permissions][:inheritable][:edit][:individual] ].should == ["julius_caesar"]
-        subject[Hydra.config[:permissions][:inheritable][:embargo_release_date] ].should == "2102-10-01"
+        expect(subject[Hydra.config[:permissions][:inheritable][:embargo_release_date] ]).to eq Date.parse("2102-10-01").to_time.utc.iso8601
       end
     end
 

--- a/hydra-access-controls/spec/unit/config_spec.rb
+++ b/hydra-access-controls/spec/unit/config_spec.rb
@@ -42,6 +42,7 @@ describe Hydra::Config do
   it "should have defaults" do
     config.permissions.read.individual.should == 'read_access_person_ssim'
     config.permissions.embargo_release_date.should == 'embargo_release_date_dtsi'
+    config.permissions.embargo.release_date.should == 'embargo_release_date_dtsi'
     config.user_model.should == 'User'
   end
 

--- a/hydra-access-controls/spec/unit/embargoable_spec.rb
+++ b/hydra-access-controls/spec/unit/embargoable_spec.rb
@@ -1,0 +1,287 @@
+require 'spec_helper'
+
+describe Hydra::AccessControls::Embargoable do
+
+  let(:model) {
+    Class.new(ActiveFedora::Base) {
+      def save(returning_value = true)
+        valid? && run_callbacks(:save) && !!returning_value
+      end
+      
+      include Hydra::AccessControls::Embargoable  
+    }
+  }
+
+  let(:future_date) { Date.today+2 }
+  let(:past_date) { Date.today-2 }
+  let(:persistence) {
+    subject.rightsMetadata
+  }
+
+  subject { model.new }
+
+  context 'visibility=' do
+    it "when changing from embargo, wipes out associated embargo metadata" do
+      subject.embargo_release_date = future_date.to_s
+      expect(subject).to receive(:deactivate_embargo!)
+      subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+    it "when changing from lease, wipes out associated lease metadata" do
+      subject.lease_expiration_date = future_date.to_s
+      expect(subject).to receive(:deactivate_lease!)
+      subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+  end
+  context 'apply_embargo' do
+    it "applies appropriate embargo_visibility settings" do
+      subject.apply_embargo(future_date.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+      expect(subject).to be_under_embargo
+      expect(subject.visibility).to eq  Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      expect(subject.embargo_release_date).to eq future_date.to_time.utc
+      expect(subject.visibility_after_embargo).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+    it "relies on default before/after visibility if none provided" do
+      subject.apply_embargo(future_date.to_s)
+      expect(subject).to be_under_embargo
+      expect(subject.visibility).to eq  Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      expect(subject.embargo_release_date).to eq future_date.to_time.utc
+      expect(subject.visibility_after_embargo).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+    end
+  end
+  context 'deactivate_embargo!' do
+    it "should remove the associated embargo information and record it in the object's embargo history" do
+      subject.embargo_release_date = past_date.to_s
+      subject.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      subject.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      subject.deactivate_embargo!
+      expect(subject.embargo_release_date).to be_nil
+      expect(subject.visibility_during_embargo).to be_nil
+      expect(subject.visibility_after_embargo).to be_nil
+      expect(subject.embargo_history.last).to include("An expired embargo was deactivated on #{Date.today}.")
+    end
+  end
+
+  context 'apply_lease' do
+    it "applies appropriate embargo_visibility settings" do
+      subject.apply_lease(future_date.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE)
+      expect(subject).to be_active_lease
+      expect(subject.visibility).to eq  Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      expect(subject.lease_expiration_date).to eq future_date.to_time.utc
+      expect(subject.visibility_after_lease).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
+    it "relies on default before/after visibility if none provided" do
+      subject.apply_lease(future_date.to_s)
+      expect(subject.visibility_during_lease).to eq  Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      expect(subject.lease_expiration_date).to eq future_date.to_time.utc
+      expect(subject.visibility_after_lease).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
+  end
+
+  context 'deactivate_lease!' do
+    it "should remove the associated embargo information and record it in the object's embargo history" do
+      subject.lease_expiration_date = past_date.to_s
+      subject.visibility_during_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      subject.visibility_after_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      subject.deactivate_lease!
+      expect(subject.lease_expiration_date).to be_nil
+      expect(subject.visibility_during_lease).to be_nil
+      expect(subject.visibility_after_lease).to be_nil
+      expect(subject.lease_history.last).to include("An expired lease was deactivated on #{Date.today}.")
+    end
+  end
+
+  context 'under_embargo?' do
+    context "when embargo date is past" do
+      it "should return false" do
+        subject.embargo_release_date = past_date.to_s
+        expect(subject).to_not be_under_embargo
+      end
+    end
+    context "when embargo date is in future" do
+      it "should return true" do
+        subject.embargo_release_date = future_date.to_s
+        expect(subject).to be_under_embargo
+      end
+    end
+  end
+
+  context 'validate_embargo' do
+    before do
+      subject.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      subject.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+    context "(embargo still in effect)" do
+      it 'returns true if current visibility matches visibility_during_embargo' do
+        subject.visibility = subject.visibility_during_embargo
+        subject.embargo_release_date = future_date.to_s
+        expect(subject.validate_embargo).to be true
+      end
+      it 'records a failures in record.errors[:embargo]' do
+        subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+        subject.embargo_release_date = future_date.to_s
+        expect(subject.validate_embargo).to be false
+        expect(subject.errors[:embargo].first).to eq "An embargo is in effect for this object until #{subject.embargo_release_date}.  Until that time the visibility should be #{Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE} but it is currently #{Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED}.  Call embargo_visibility! on this object to repair."
+      end
+    end
+    context "(embargo expired)" do
+      it 'returns true if current visibility matches visibility_after_embargo' do
+        subject.visibility = subject.visibility_after_embargo
+        subject.embargo_release_date = past_date.to_s
+        expect(subject.validate_embargo).to be true
+      end
+      it '(embargo expired) records a failures in record.errors[:embargo]' do
+        subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        subject.embargo_release_date = past_date.to_s
+        expect(subject.validate_embargo).to be false
+        expect(subject.errors[:embargo].first).to eq "The embargo expired on #{subject.embargo_release_date}.  The visibility should be #{Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC} but it is currently #{Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE}.  Call embargo_visibility! on this object to repair."
+      end
+    end
+  end
+
+
+  context 'embargo_visibility!' do
+    let(:future_date) { 2.days.from_now }
+    let(:past_date) { 2.days.ago }
+    before do
+      subject.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      subject.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+    context 'when embargo expired' do
+      it 'applies visibility_after_embargo and calls after_apply_embargo' do
+        subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        subject.embargo_release_date = past_date.to_s
+        expect(subject).to receive(:deactivate_embargo!)
+        subject.embargo_visibility!
+        expect(subject.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      end
+      it "defaults to private if visibility_after_embargo is not set" do
+        subject.visibility_after_embargo = nil
+        subject.embargo_release_date = past_date.to_s
+        subject.embargo_visibility!
+        expect(subject.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      end
+    end
+    context 'when embargo still in effect' do
+      it 'applies visibility_during_embargo' do
+        subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        subject.embargo_release_date = future_date.to_s
+        expect(subject).to_not receive(:deactivate_embargo!)
+        subject.embargo_visibility!
+        expect(subject.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      end
+      it 'sets before/after visibility to defaults if none provided' do
+        subject.visibility_during_embargo = nil
+        subject.visibility_after_embargo = nil
+        subject.embargo_release_date = future_date.to_s
+        subject.embargo_visibility!
+        expect(subject.visibility_during_embargo).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        expect(subject.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        expect(subject.visibility_after_embargo).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      end
+    end
+  end
+
+  context 'validate_lease' do
+    let(:future_date) { 2.days.from_now }
+    let(:past_date) { 2.days.ago }
+    before do
+      subject.visibility_during_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      subject.visibility_after_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
+    context "(lease expired)" do
+      it 'returns true if current visibility matches visibility_after_lease' do
+        subject.visibility = subject.visibility_after_lease
+        subject.lease_expiration_date = past_date.to_s
+        expect(subject.validate_lease).to be true
+      end
+      it 'records a failures in record.errors[:lease]' do
+        subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        subject.lease_expiration_date = past_date.to_s
+        expect(subject.validate_lease).to be false
+        expect(subject.errors[:lease].first).to eq "The lease expired on #{subject.lease_expiration_date}.  The visibility should be #{Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE} but it is currently #{Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC}.  Call lease_visibility! on this object to repair."
+      end
+    end
+    context "(lease still in effect)" do
+      it 'returns true if current visibility matches visibility_during_embargo' do
+        subject.visibility = subject.visibility_during_lease
+        subject.lease_expiration_date = future_date.to_s
+        expect(subject.validate_lease).to be true
+      end
+      it 'records a failures in record.errors[:lease]' do
+        subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+        subject.lease_expiration_date = future_date.to_s
+        expect(subject.validate_lease).to be false
+        expect(subject.errors[:lease].first).to eq "A lease is in effect for this object until #{subject.lease_expiration_date}.  Until that time the visibility should be #{Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC} but it is currently #{Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED}.  Call lease_visibility! on this object to repair."
+      end
+    end
+
+  end
+
+
+  context 'lease_visibility!' do
+    before do
+      subject.visibility_during_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      subject.visibility_after_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
+    context 'when lease expired' do
+      it 'applies visibility_after_lease and calls after_apply_lease' do
+        subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        subject.lease_expiration_date = past_date.to_s
+        expect(subject).to receive(:deactivate_lease!)
+        subject.lease_visibility!
+        expect(subject.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      end
+      it "defaults to private if visibility_after_lease is not set" do
+        subject.visibility_after_lease = nil
+        subject.lease_expiration_date = past_date.to_s
+        subject.lease_visibility!
+        expect(subject.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      end
+    end
+    context 'when lease still in effect' do
+      it 'applies visibility_during_lease and calls after_apply_lease' do
+        subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        subject.lease_expiration_date = future_date.to_s
+        expect(subject).to_not receive(:deactivate_lease!)
+        subject.lease_visibility!
+        expect(subject.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      end
+      it 'sets before/after visibility to defaults if none provided' do
+        subject.visibility_during_lease = nil
+        subject.visibility_after_lease = nil
+        subject.lease_expiration_date = future_date.to_s
+        subject.lease_visibility!
+        expect(subject.visibility_during_lease).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+        expect(subject.visibility_after_lease).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      end
+    end
+  end
+
+
+  context 'persistence' do
+    let(:the_date) { 2.days.from_now }
+
+    it 'persists a date object' do
+      subject.embargo_release_date = the_date
+      expect(persistence.embargo_release_date.first).to be_kind_of DateTime
+    end
+
+    it 'persists a valid string' do
+      subject.embargo_release_date = the_date.to_s
+      expect(persistence.embargo_release_date.first).to be_kind_of DateTime
+    end
+
+    it 'raises an error on an empty string' do
+      expect {
+        subject.embargo_release_date = ''
+      }.to raise_error OM::TypeMismatch
+    end
+
+    it 'does not persist an invalid string' do
+      expect {
+        subject.embargo_release_date = "Tim"
+      }.to raise_error OM::TypeMismatch
+    end
+  end
+
+end

--- a/hydra-access-controls/spec/unit/hydra_rights_metadata_spec.rb
+++ b/hydra-access-controls/spec/unit/hydra_rights_metadata_spec.rb
@@ -114,7 +114,7 @@ describe Hydra::Datastream::RightsMetadata do
     it "should return a hash of all individuals with permissions set, along with their permission levels" do
       @sample.permissions({"person"=>"person_123"}, "read")
       @sample.permissions({"person"=>"person_456"}, "edit")
-      @sample.individuals.should == {"person_123"=>"read", "person_456"=>"edit"}
+      expect(@sample.users).to eq("person_123"=>"read", "person_456"=>"edit")
     end
   end
   
@@ -140,8 +140,8 @@ describe Hydra::Datastream::RightsMetadata do
     end
     it "clears permissions" do
       @sample.clear_permissions!
-      @sample.individuals.should == {}
-      @sample.groups.should == {}
+      expect(@sample.users).to eq({})
+      expect(@sample.groups).to eq({})
     end
   end
   
@@ -167,44 +167,113 @@ describe Hydra::Datastream::RightsMetadata do
       solr_doc["read_access_group_ssim"].should == ["public"]
       solr_doc["discover_access_group_ssim"].should == ["bob"]
     end
+
+    it "should solrize embargo information if set" do
+      @sample.embargo_release_date = DateTime.parse("2010-12-01T23:59:59+0")
+      solr_doc = @sample.to_solr
+      expect(solr_doc["embargo_release_date_dtsi"]).to eq "2010-12-01T23:59:59Z"
+    end
+
+    it "should solrize lease information if set" do
+      @sample.lease_expiration_date = DateTime.parse("2010-12-01T23:59:59Z")
+      solr_doc = @sample.to_solr
+      expect(solr_doc["lease_expiration_date_dtsi"]).to eq "2010-12-01T23:59:59Z"
+    end
   end
+
+  #
+  # Embargo
+  #
   describe "embargo_release_date=" do
     it "should update the appropriate node with the value passed" do
-      @sample.embargo_release_date=("2010-12-01")
-      @sample.embargo_release_date.should == "2010-12-01"
-    end
-    it "should only accept valid date values" do
-      
+      @sample.embargo_release_date = Date.parse("2010-12-01")
+      expect(@sample.embargo_release_date).to eq [Date.parse("2010-12-01").to_time.utc]
     end
     it "should accept a nil value after having a date value" do
-      @sample.embargo_release_date=("2010-12-01")
-      @sample.embargo_release_date=(nil)
-      @sample.embargo_release_date.should == nil
+      @sample.embargo_release_date = Date.parse("2010-12-01")
+      @sample.embargo_release_date = nil
+      expect(@sample.embargo_release_date).to be_empty
     end
   end
+
   describe "embargo_release_date" do
     it "should return solr formatted date" do
-      @sample.embargo_release_date=("2010-12-01")
-      @sample.embargo_release_date(:format=>:solr_date).should == "2010-12-01T23:59:59Z"
-    end
-    
-    # this test was returning '' under 1.9 and returning nil under ree and 1.8.7
-    it "should not return anything if the date is empty string" do
-      @sample.update_values({[:embargo,:machine,:date]=>''})
-      @sample.embargo_release_date(:format=>:solr_date).should be_blank
+      @sample.embargo_release_date = DateTime.parse("2010-12-01T23:59:59Z")
+      expect(@sample.embargo_release_date).to eq [DateTime.parse("2010-12-01T23:59:59Z")]
     end
   end
+
   describe "under_embargo?" do
     it "should return true if the current date is before the embargo release date" do
       @sample.embargo_release_date=Date.today+1.month
-      @sample.under_embargo?.should be_true
+      expect(@sample).to be_under_embargo
     end
     it "should return false if the current date is after the embargo release date" do
       @sample.embargo_release_date=Date.today-1.month
-      @sample.under_embargo?.should be_false
+      expect(@sample).to_not be_under_embargo
     end
     it "should return false if there is no embargo date" do
-      @sample.under_embargo?.should be_false
+      @sample.embargo_release_date = nil
+      expect(@sample).to_not be_under_embargo
+    end
+  end
+  describe "visibility during/after embargo" do
+    it "should track visibility values and index them into solr" do
+      expect(@sample.visibility_during_embargo).to be_empty
+      expect(@sample.visibility_after_embargo).to be_empty
+      @sample.visibility_during_embargo = "private"
+      @sample.visibility_after_embargo = "restricted"
+      expect(@sample.visibility_during_embargo).to eq ["private"]
+      expect(@sample.visibility_after_embargo).to eq ["restricted"]
+      solr_doc = @sample.to_solr
+      expect(solr_doc["visibility_during_embargo_ssim"]).to eq ["private"]
+      expect(solr_doc["visibility_after_embargo_ssim"]).to eq ["restricted"]
+    end
+  end
+
+  #
+  # Leases
+  #
+  describe "lease_expiration_date=" do
+    it "should update the appropriate node with the value passed" do
+      @sample.lease_expiration_date = "2010-12-01"
+      expect(@sample.lease_expiration_date).to eq [Date.parse("2010-12-01").to_time.utc]
+    end
+    it "should only accept valid date values" do
+
+    end
+    it "should accept a nil value after having a date value" do
+      @sample.lease_expiration_date = "2010-12-01"
+      @sample.lease_expiration_date = nil
+      expect(@sample.lease_expiration_date).to be_empty
+    end
+  end
+
+  describe "active_lease?" do
+    it "should return true if the current date is after the lease expiration date" do
+      @sample.lease_expiration_date = Date.today-1.month
+      expect(@sample).to_not be_active_lease
+    end
+    it "should return false if the current date is before the lease expiration date" do
+      @sample.lease_expiration_date = Date.today+1.month
+      expect(@sample).to be_active_lease
+    end
+    it "should return false if there is no lease expiration date" do
+      @sample.lease_expiration_date = nil
+      expect(@sample).to_not be_active_lease
+    end
+  end
+  describe "visibility during/after lease" do
+    it "should track visibility values and index them into solr" do
+      expect(@sample.visibility_during_lease).to be_empty
+      expect(@sample.visibility_after_lease).to be_empty
+      @sample.visibility_during_lease = "restricted"
+      @sample.visibility_after_lease = "private"
+      expect(@sample.visibility_during_lease).to eq ["restricted"]
+      expect(@sample.visibility_after_lease).to eq ["private"]
+      solr_doc = @sample.to_solr
+      expect(solr_doc["visibility_during_lease_ssim"]).to eq ["restricted"]
+      expect(solr_doc["visibility_after_lease_ssim"]).to eq ["private"]
     end
   end
 end

--- a/hydra-access-controls/spec/unit/inheritable_rights_metadata_spec.rb
+++ b/hydra-access-controls/spec/unit/inheritable_rights_metadata_spec.rb
@@ -1,23 +1,26 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require "nokogiri"
 
 describe Hydra::Datastream::InheritableRightsMetadata do
   before do
-    Hydra.stub(:config).and_return({:permissions=>{
-      :discover => {:group =>"discover_access_group_ssim", :individual=>"discover_access_person_ssim"},
-      :read => {:group =>"read_access_group_ssim", :individual=>"read_access_person_ssim"},
-      :edit => {:group =>"edit_access_group_ssim", :individual=>"edit_access_person_ssim"},
-      :owner => "depositor_ssim",
-      :embargo_release_date => "embargo_release_date_dtsi",
-      
-      :inheritable => {
-        :discover => {:group =>"inheritable_discover_access_group_ssim", :individual=>"inheritable_discover_access_person_ssim"},
-        :read => {:group =>"inheritable_read_access_group_ssim", :individual=>"inheritable_read_access_person_ssim"},
-        :edit => {:group =>"inheritable_edit_access_group_ssim", :individual=>"inheritable_edit_access_person_ssim"},
-        :owner => "inheritable_depositor_ssim",
-        :embargo_release_date => "inheritable_embargo_release_date_dtsi"
-      }
-    }})
+    Hydra.stub(:config).and_return(
+      Hydra::Config.new.tap do |config|
+        config.permissions ={
+          :discover => {:group =>"discover_access_group_ssim", :individual=>"discover_access_person_ssim"},
+          :read => {:group =>"read_access_group_ssim", :individual=>"read_access_person_ssim"},
+          :edit => {:group =>"edit_access_group_ssim", :individual=>"edit_access_person_ssim"},
+          :owner => "depositor_ssim",
+          :embargo_release_date => "embargo_release_date_dtsi",
+
+          :inheritable => {
+            :discover => {:group =>"inheritable_discover_access_group_ssim", :individual=>"inheritable_discover_access_person_ssim"},
+            :read => {:group =>"inheritable_read_access_group_ssim", :individual=>"inheritable_read_access_person_ssim"},
+            :edit => {:group =>"inheritable_edit_access_group_ssim", :individual=>"inheritable_edit_access_person_ssim"},
+            :owner => "inheritable_depositor_ssim",
+            :embargo_release_date => "inheritable_embargo_release_date_dtsi"
+          }
+        }
+      end
+    )
   end
   
   before(:each) do
@@ -55,7 +58,7 @@ describe Hydra::Datastream::InheritableRightsMetadata do
       subject[Hydra.config[:permissions][:inheritable][:read][:individual] ].should == ["nero"]
       subject[Hydra.config[:permissions][:inheritable][:edit][:group] ].should == ["africana-faculty", "cool-kids"]
       subject[Hydra.config[:permissions][:inheritable][:edit][:individual] ].should == ["julius_caesar"]
-      subject[Hydra.config[:permissions][:inheritable][:embargo_release_date] ].should == "2102-10-01"
+      expect(subject[Hydra.config[:permissions][:inheritable][:embargo_release_date]]).to eq Date.parse("2102-10-01").to_time.utc.iso8601
     end
   end
 

--- a/hydra-access-controls/spec/unit/policy_aware_ability_spec.rb
+++ b/hydra-access-controls/spec/unit/policy_aware_ability_spec.rb
@@ -167,7 +167,7 @@ describe Hydra::PolicyAwareAbility do
   end
   describe "edit_persons_from_policy" do
     it "should retrieve the list of individuals with edit access from the policy" do
-      subject.edit_persons_from_policy(@policy.pid).should == ["julius_caesar"]
+      expect(subject.edit_users_from_policy(@policy.pid)).to eq ["julius_caesar"]
     end
   end
   describe "read_groups_from_policy" do
@@ -179,7 +179,7 @@ describe Hydra::PolicyAwareAbility do
   end
   describe "read_persons_from_policy" do
     it "should retrieve the list of individuals with read access from the policy" do
-      subject.read_persons_from_policy(@policy.pid).should == ["julius_caesar","nero"]
+      expect(subject.read_users_from_policy(@policy.pid)).to eq ["julius_caesar","nero"]
     end
   end
 end

--- a/hydra-access-controls/spec/unit/policy_aware_access_controls_enforcement_spec.rb
+++ b/hydra-access-controls/spec/unit/policy_aware_access_controls_enforcement_spec.rb
@@ -142,7 +142,7 @@ describe Hydra::PolicyAwareAccessControlsEnforcement do
     it "should escape slashes in the group names" do
       RoleMapper.stub(:roles).with(@user).and_return(["abc/123","cde/567"])
       subject.stub(:current_user).and_return(@user)
-      user_access_filters = subject.apply_policy_role_permissions
+      user_access_filters = subject.apply_policy_group_permissions
       ["edit","discover","read"].each do |type|
         user_access_filters.should include("#{ActiveFedora::SolrService.solr_name("inheritable_#{type}_access_group", Hydra::Datastream::RightsMetadata.indexer )}\:abc\\\/123")
         user_access_filters.should include("#{ActiveFedora::SolrService.solr_name("inheritable_#{type}_access_group", Hydra::Datastream::RightsMetadata.indexer )}\:cde\\\/567")
@@ -151,7 +151,7 @@ describe Hydra::PolicyAwareAccessControlsEnforcement do
     it "should escape spaces in the group names" do
       RoleMapper.stub(:roles).with(@user).and_return(["abc 123","cd/e 567"])
       subject.stub(:current_user).and_return(@user)
-      user_access_filters = subject.apply_policy_role_permissions
+      user_access_filters = subject.apply_policy_group_permissions
       ["edit","discover","read"].each do |type|
         user_access_filters.should include("#{ActiveFedora::SolrService.solr_name("inheritable_#{type}_access_group", Hydra::Datastream::RightsMetadata.indexer )}\:abc\\ 123")
         user_access_filters.should include("#{ActiveFedora::SolrService.solr_name("inheritable_#{type}_access_group", Hydra::Datastream::RightsMetadata.indexer )}\:cd\\\/e\\ 567")

--- a/hydra-core/spec/test_app_templates/Gemfile.extra
+++ b/hydra-core/spec/test_app_templates/Gemfile.extra
@@ -2,4 +2,5 @@ group :develop do
   gem 'active-fedora', github: "projecthydra/active_fedora"
 end
 gem 'rspec-rails', '~> 2.99', group: :test
+gem 'rspec-its'
 


### PR DESCRIPTION
...and visibility_after

refs curationexperts/absolute#34
- adds embargo/lease history and deactivation date
- indexes lease_expiration_date when it is set
- adds lease_active?
- (minor) cleaning up deprecation warnings
- adds embargo and lease services
