### PR TITLE
Unifying download response header behavior

### DIFF
--- a/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
+++ b/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
@@ -83,8 +83,7 @@ module Hydra
         elsif request.headers['HTTP_RANGE']
           send_range
         else
-          send_file_headers! content_options
-          self.response_body = datastream.stream
+          send_file_contents
         end
       end
 
@@ -117,10 +116,22 @@ module Hydra
         response.headers['Content-Range'] = "bytes #{from}-#{to}/#{datastream.dsSize}"
         response.headers['Content-Length'] = "#{length}"
         self.status = 206
-        send_file_headers! content_options
+        prepare_file_headers
         self.response_body = datastream.stream(from, length)
       end
+
+      def send_file_contents
+        self.status = 200
+        prepare_file_headers
+        self.response_body = datastream.stream
+      end
       
+      def prepare_file_headers
+        send_file_headers! content_options
+        response.headers['Content-Type'] = datastream.mimeType
+        self.content_type = datastream.mimeType
+      end
+
       private 
       
       def default_content_ds


### PR DESCRIPTION
1) Refactoring DownloadBehavior#send_content so that the case
   statement is operating at the same level of abstraction.
2) Extracting common behavior for setting response headers for both
   streaming and sending the content all at once
3) Adding explicit declaration of content type in file headers.

Of these, the explicit declaration is fixing behavior so that the
'Content-Type' response header is set in Chrome v32, Safari v7, and
Firefox v29. Without the following code, the Content-Type is not set:

``` ruby
response.headers['Content-Type'] = datastream.mimeType
self.content_type = datastream.mimeType
```

This may be an upstream bug in Rails. As a side note, Hydra::Core is
using a private function `#send_file_headers!` which could create
problems going forward.
