### PR TITLE
Respect SOLR_URL even in test

### DIFF
--- a/hydra-core/lib/generators/hydra/templates/config/blacklight.yml
+++ b/hydra-core/lib/generators/hydra/templates/config/blacklight.yml
@@ -3,8 +3,7 @@ development:
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>
 test: &test
   adapter: solr
-  url: http://localhost:<%= ENV['SOLR_TEST_PORT'] || 8985 %>/solr/hydra-test
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8985)}/solr/hydra-test" %>
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
-


### PR DESCRIPTION
There was no legitimate reason to have structurally and semantically different behavior here.