### PR TITLE
stream_body uses response.body = iostream

### DIFF
--- a/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
+++ b/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
@@ -120,12 +120,18 @@ module Hydra
 
       private
 
+      # Previous implementation looped and used response.stream.write, but we
+      # found that had a problem with delay in HTTP response headers being
+      # sent, which this implementation fixed while still streaming.
+      # https://github.com/samvera/hydra-head/pull/421
       def stream_body(iostream)
-        iostream.each do |in_buff|
-          response.stream.write in_buff
+        # see https://github.com/rails/rails/issues/18714#issuecomment-96204444
+        unless response.headers["Last-Modified"] || response.headers["ETag"]
+          Rails.logger.warn("Response may be buffered instead of streaming, best to set a Last-Modified or ETag header")
         end
-      ensure
-        response.stream.close
+
+        render nothing: true
+        response.body = iostream
       end
 
       def default_file


### PR DESCRIPTION
instead of a loop of response.stream.write's.

Rails still streams with this new implementation. But it is delivering the HTTP response
headers a lot faster this way, almost immediately.

With the previous way, with a 1G original file accessed via
/downloads, I was seeing an 11 second wait even to get HTTP headers.

Not sure why, it could be because it takes that long to even get
the first byte from fedora, and it's not sending anything until it does?
But I tried to mess around with things using the response.stream.write
API, and was not able to improve things.

Browsers are willing to wait that long, but it's not a great UX -- you get
a 'waiting for connection' popup in chrome until the HTTP  headers (in my
case 11 seconds later), only at that point does it show up as a download in progress.

But some non-browser user agents are not even willing to wait that long. imgix.com
is willing to wait at most 10 seconds for HTTP headers (after that it will wait quite a bit longer for the entire content to stream), which honestly seems like it should be pretty generous. 
Other CDNs may be similar.

Ensuring quick HTTP header response seems a good idea, and this change
seems to accomplish it. Even my 1G file had nearly immediately HTTTP header
delivery, although of course you still have to wait for the actual file contents
to download. 

For some background on response.body = stream as a valid rails
streaming API, see https://github.com/rails/rails/issues/18714