### PR TITLE
Drop yard as a dependency

### DIFF
--- a/hydra-core/hydra-core.gemspec
+++ b/hydra-core/hydra-core.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'hydra-access-controls', version
 
   gem.add_development_dependency 'sqlite3', '~> 1.3'
-  gem.add_development_dependency 'yard', '~> 0.8.7'
   gem.add_development_dependency 'rspec-rails', '~> 3.1'
   gem.add_development_dependency 'factory_girl_rails', '~> 4.2'
 end


### PR DESCRIPTION
It has a security vulnerability https://nvd.nist.gov/vuln/detail/CVE-2017-17042
and we aren't using it anyway.