### PR TITLE
Fix download streaming with self.response_body=

### DIFF
--- a/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
+++ b/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
@@ -125,11 +125,7 @@ module Hydra
         unless response.headers["Last-Modified"] || response.headers["ETag"]
           Rails.logger.warn("Response may be buffered instead of streaming, best to set a Last-Modified or ETag header")
         end
-        iostream.each do |in_buff|
-          response.stream.write in_buff
-        end
-      ensure
-        response.stream.close
+        self.response_body = iostream
       end
 
       def default_file


### PR DESCRIPTION
We have been seeing lots of extra memory usage when downloading large
files from Fedora. There was a version of this fix applied in #421, but
it was reverted in #427. This uses the recommended technique of setting
the controller's response_body to the stream.

In looking through the ActionController source, this should both start
the output (sending headers), and flag the render as having performed,
so implicit template resolution/rendering will be skipped.

I have another version of this patch against 10.5.0, but there is no branch in the main repository for 10.x. It would be good to determine whether Hyrax 1.x can use 11.0 or if there should be a 10.5.1 or 10.6.0 release -- this is a major threat to production applications with large files. We were seeing ~25 puma workers per hour terminated by oom-killer at 40GB+ of memory.

Fixes #434  ; refs #421 ; refs #427 

@projecthydra/hydra-contributors
