### PR TITLE
Backports for 10.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: ruby
 sudo: false
-rvm: 2.4.1
+rvm: 2.4.2
 
 matrix:
   include:
-    - rvm: 2.3.4
-      env: "BLACKLIGHT_VERSION=5.17.2"
+    - env: "RAILS_VERION=5.1.4"
+    - rvm: 2.3.5
+      env: "BLACKLIGHT_VERSION=5.17.2 RAILS_VERSION=5.0.6"
 
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-    - RAILS_VERSION=5.0.2
-    - BLACKLIGHT_VERSION=6.9.0
+    - BLACKLIGHT_VERSION=6.12.0
 before_install:
   - gem update --system
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@ Contributors to this project:
 *  Graeme West
 *  Jeremy Friesen
 *  Jessie Keck
+*  Joe Atzberger
 *  John Scofield
 *  Joseph Gilbert
 *  Justin Coyne

--- a/README.md
+++ b/README.md
@@ -1,45 +1,43 @@
 # Hydra-Head
 
-[![Build Status](https://travis-ci.org/projecthydra/hydra-head.png?branch=master)](https://travis-ci.org/projecthydra/hydra-head)
+[![Build Status](https://travis-ci.org/samvera/hydra-head.png?branch=master)](https://travis-ci.org/samvera/hydra-head)
 [![Version](https://badge.fury.io/rb/hydra-head.png)](http://badge.fury.io/rb/hydra-head)
-[![Dependencies](https://gemnasium.com/projecthydra/hydra-head.png)](https://gemnasium.com/projecthydra/hydra-head)
-[![Coverage Status](https://img.shields.io/coveralls/projecthydra/hydra-head.svg)](https://coveralls.io/r/projecthydra/hydra-head)
+[![Dependencies](https://gemnasium.com/samvera/hydra-head.png)](https://gemnasium.com/samvera/hydra-head)
+[![Coverage Status](https://img.shields.io/coveralls/samvera/hydra-head.svg)](https://coveralls.io/r/samvera/hydra-head)
 
 Hydra-Head is a Ruby-on-Rails gem containing the core code for a web
-application using the full stack of hydra building blocks.
+application using the full stack of Samvera building blocks.
 
 See the Github wikis for information targeted to developers:
-<http://github.com/projecthydra/hydra-head/wiki>
+<http://github.com/samvera/hydra-head/wiki>
 
 See the Duraspace Hydra wikis for information at the architecture level:
-<http://wiki.duraspace.org/display/hydra/>
+<http://wiki.duraspace.org/display/samvera/>
 
 Additionally, new adopters and potential adopters may find the pages
-here useful: <http://projecthydra.org/>
+here useful: <http://samvera.org/>
 
 If you are new to Hydra and looking to start a new Hydra head with a set
 of components that have been tested for compatibility, and for which
 there will be a documented upgrade path to the next versions, we
-recommend you use the Hydra gem: https://github.com/projecthydra/hydra
+recommend you use the Hydra gem: https://github.com/samvera/hydra
 
-Further questions? Ask the [hydra-tech
-list](http://groups.google.com/group/hydra-tech) or join the freenode
-\#projecthydra IRC channel.
+Further questions? [Get in touch](https://wiki.duraspace.org/pages/viewpage.action?pageId=87460391)
 
 ## Installation/Setup
 
 This process is covered step-by-step in the [Tutorial: Dive Into
-Hydra](https://github.com/projecthydra/hydra/wiki/Dive-into-Hydra)
+Hydra](https://github.com/samvera/hydra/wiki/Dive-into-Hydra)
 
 ### Installation Prerequisites
 
-See the [Installation Prerequisites](http://github.com/projecthydra/hydra-head/wiki/Installation-Prerequisites) wiki page.
+See the [Installation Prerequisites](http://github.com/samvera/hydra-head/wiki/Installation-Prerequisites) wiki page.
 
-Ruby 1.9.3+ is required by Hydra-Head release 6+; RVM is strongly suggested.
+Ruby 2.1.0+ is required by Hydra-Head release 10+; RVM is strongly suggested.
 
 ### Install Rails
 
-    gem install 'rails' --version '~>4.0.0'
+    gem install 'rails' --version '~>5.1.0'
 
 ### Generate a new rails application:
 
@@ -82,16 +80,16 @@ Run the database migrations
 Congratulations. You've set up the code for your Hydra Head.
 
 Read [Tools for Developing and Testing your
-Application](http://github.com/projecthydra/hydra-head/wiki/Tools-for-Developing-and-Testing-your-Application),
+Application](http://github.com/samvera/hydra-head/wiki/Tools-for-Developing-and-Testing-your-Application),
 then read [How to Get
-Started](http://github.com/projecthydra/hydra-head/wiki/How-to-Get-Started)
+Started](http://github.com/samvera/hydra-head/wiki/How-to-Get-Started)
 to get a sense of what you can do with your Hydra Head.
 
 ## Modifying and Testing the hydra-head Gem
 
 For those developers who want to or need to work on the hydra-head gem
 itself, see the [Instructions for
-Contributors](http://github.com/projecthydra/hydra-head/wiki/For-Contributors)
+Contributors](http://github.com/samvera/hydra-head/wiki/For-Contributors)
 
 ## Acknowledgments
 

--- a/hydra-access-controls/spec/factories.rb
+++ b/hydra-access-controls/spec/factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
 
   # Users
 

--- a/hydra-access-controls/spec/services/embargo_service_spec.rb
+++ b/hydra-access-controls/spec/services/embargo_service_spec.rb
@@ -5,19 +5,19 @@ describe Hydra::EmbargoService do
   let(:past_date) { 2.days.ago }
 
   let!(:work_with_expired_embargo1) do
-    FactoryGirl.build(:asset, embargo_release_date: past_date.to_s).tap do |work|
+    FactoryBot.build(:asset, embargo_release_date: past_date.to_s).tap do |work|
       work.save(validate:false)
     end
   end
 
   let!(:work_with_expired_embargo2) do
-    FactoryGirl.build(:asset, embargo_release_date: past_date.to_s).tap do |work|
+    FactoryBot.build(:asset, embargo_release_date: past_date.to_s).tap do |work|
       work.save(validate:false)
     end
   end
 
-  let!(:work_with_embargo_in_effect) { FactoryGirl.create(:asset, embargo_release_date: future_date.to_s)}
-  let!(:work_without_embargo) { FactoryGirl.create(:asset)}
+  let!(:work_with_embargo_in_effect) { FactoryBot.create(:asset, embargo_release_date: future_date.to_s)}
+  let!(:work_without_embargo) { FactoryBot.create(:asset)}
 
   describe "#assets_with_expired_embargoes" do
     it "returns an array of assets with expired embargoes" do

--- a/hydra-access-controls/spec/services/lease_service_spec.rb
+++ b/hydra-access-controls/spec/services/lease_service_spec.rb
@@ -5,19 +5,19 @@ describe Hydra::LeaseService do
   let(:past_date) { 2.days.ago }
 
   let!(:work_with_expired_lease1) do
-    FactoryGirl.build(:asset, lease_expiration_date: past_date.to_s).tap do |work|
+    FactoryBot.build(:asset, lease_expiration_date: past_date.to_s).tap do |work|
       work.save(validate: false)
     end
   end
 
   let!(:work_with_expired_lease2) do
-    FactoryGirl.build(:asset, lease_expiration_date: past_date.to_s).tap do |work|
+    FactoryBot.build(:asset, lease_expiration_date: past_date.to_s).tap do |work|
       work.save(validate: false)
     end
   end
 
-  let!(:work_with_lease_in_effect) { FactoryGirl.create(:asset, lease_expiration_date: future_date.to_s)}
-  let!(:work_without_lease) { FactoryGirl.create(:asset)}
+  let!(:work_with_lease_in_effect) { FactoryBot.create(:asset, lease_expiration_date: future_date.to_s)}
+  let!(:work_without_lease) { FactoryBot.create(:asset)}
 
   describe "#assets_with_expired_leases" do
     it "returns an array of assets with expired embargoes" do

--- a/hydra-access-controls/spec/spec_helper.rb
+++ b/hydra-access-controls/spec/spec_helper.rb
@@ -35,7 +35,7 @@ ActiveSupport::Dependencies.autoload_paths += relative_load_paths
 require 'support/mods_asset'
 require 'support/solr_document'
 require "support/user"
-require "factory_girl"
+require "factory_bot"
 require 'rspec/mocks'
 require 'rspec/its'
 require "factories"

--- a/hydra-access-controls/spec/unit/ability_spec.rb
+++ b/hydra-access-controls/spec/unit/ability_spec.rb
@@ -31,7 +31,7 @@ describe Ability do
   end
 
   context "for a signed in user" do
-    let(:user) { FactoryGirl.build(:registered_user) }
+    let(:user) { FactoryBot.build(:registered_user) }
 
     it { should_not be_able_to(:create, ActiveFedora::Base) }
   end
@@ -42,7 +42,7 @@ describe Ability do
 #   Test coverage for discover permission is in spec/requests/gated_discovery_spec.rb
 
   describe "Given an asset that has been made publicly discoverable" do
-    let(:asset) { FactoryGirl.create(:asset) }
+    let(:asset) { FactoryBot.create(:asset) }
     before do
       asset.permissions_attributes = [{ name: "public", access: "discover", type: "group" }, { name: "joe_creator", access: "edit", type: "person" }, { name: "calvin_collaborator", access: "edit", type: "person" }]
       asset.save
@@ -58,7 +58,7 @@ describe Ability do
     end
 
     context "Then a registered user" do
-      let(:user) { FactoryGirl.build(:registered_user) }
+      let(:user) { FactoryBot.build(:registered_user) }
       it { should     be_able_to(:discover, asset) }
       it { should_not be_able_to(:read, asset) }
       it { should_not be_able_to(:edit, asset) }
@@ -68,8 +68,8 @@ describe Ability do
   end
 
   describe "Given an asset that has been made publicly available (ie. open access)" do
-    #let(:asset) { FactoryGirl.create(:open_access_asset) }
-    let(:asset) { FactoryGirl.create(:asset) }
+    #let(:asset) { FactoryBot.create(:open_access_asset) }
+    let(:asset) { FactoryBot.create(:asset) }
     before do
       asset.permissions_attributes = [{ name: "public", access: "read", type: "group" }, { name: "joe_creator", access: "edit", type: "person" }, { name: "calvin_collaborator", access: "edit", type: "person" }]
       asset.save
@@ -85,7 +85,7 @@ describe Ability do
     end
 
     context "Then a registered user" do
-      let(:user) { FactoryGirl.build(:registered_user) }
+      let(:user) { FactoryBot.build(:registered_user) }
       it { should     be_able_to(:discover, asset) }
       it { should     be_able_to(:read, asset) }
       it { should_not be_able_to(:edit, asset) }
@@ -95,7 +95,7 @@ describe Ability do
   end
 
   describe "Given an asset with no custom access set" do
-    let(:asset) { FactoryGirl.create(:asset) }
+    let(:asset) { FactoryBot.create(:asset) }
     before do
       asset.permissions_attributes = [{ name: "joe_creator", access: "edit", type: "person" }]
       asset.save
@@ -110,7 +110,7 @@ describe Ability do
       it { should_not be_able_to(:destroy, asset) }
     end
     context "Then a registered user" do
-      let(:user) { FactoryGirl.build(:registered_user) }
+      let(:user) { FactoryBot.build(:registered_user) }
       it { should_not be_able_to(:discover, asset) }
       it { should_not be_able_to(:read, asset) }
       it { should_not be_able_to(:edit, asset) }
@@ -118,7 +118,7 @@ describe Ability do
       it { should_not be_able_to(:destroy, asset) }
     end
     context "Then the Creator" do
-      let(:user) { FactoryGirl.build(:joe_creator) }
+      let(:user) { FactoryBot.build(:joe_creator) }
       it { should     be_able_to(:discover, asset) }
       it { should     be_able_to(:read, asset) }
       it { should     be_able_to(:edit, asset) }
@@ -132,14 +132,14 @@ describe Ability do
   end
 
   describe "Given an asset which registered users have read access to" do
-    # let(:asset) { FactoryGirl.create(:org_read_access_asset) }
-    let(:asset) { FactoryGirl.create(:asset) }
+    # let(:asset) { FactoryBot.create(:org_read_access_asset) }
+    let(:asset) { FactoryBot.create(:asset) }
     before do
       asset.permissions_attributes = [{ name: "registered", access: "read", type: "group" }, { name: "joe_creator", access: "edit", type: "person" }, { name: "calvin_collaborator", access: "edit", type: "person" }]
       asset.save
     end
     context "The a registered user" do
-      let(:user) { FactoryGirl.build(:registered_user) }
+      let(:user) { FactoryBot.build(:registered_user) }
       before do
         allow(user).to receive(:new_record?).and_return(false)
       end
@@ -154,7 +154,7 @@ describe Ability do
   end
 
   describe "Given an asset with collaborator" do
-    let(:asset) { FactoryGirl.create(:asset) }
+    let(:asset) { FactoryBot.create(:asset) }
     before do
       asset.permissions_attributes = [{ name:"africana-faculty", access: "edit", type: "group" }, {name: "calvin_collaborator", access: "edit", type: "person"}]
       asset.save
@@ -162,7 +162,7 @@ describe Ability do
     after { asset.destroy }
 
     context "Then a collaborator with edit access (user permision)" do
-      let(:user) { FactoryGirl.build(:calvin_collaborator) }
+      let(:user) { FactoryBot.build(:calvin_collaborator) }
 
       it { should     be_able_to(:discover, asset) }
       it { should     be_able_to(:read, asset) }
@@ -173,7 +173,7 @@ describe Ability do
     end
 
     context "Then a collaborator with edit access (group permision)" do
-      let(:user) { FactoryGirl.build(:martia_morocco) }
+      let(:user) { FactoryBot.build(:martia_morocco) }
       before do
         allow(user).to receive(:groups).and_return(["faculty", "africana-faculty"])
       end
@@ -183,14 +183,14 @@ describe Ability do
   end
 
   describe "Given an asset where dept can read & registered users can discover" do
-    # let(:asset) { FactoryGirl.create(:dept_access_asset) }
-    let(:asset) { FactoryGirl.create(:asset) }
+    # let(:asset) { FactoryBot.create(:dept_access_asset) }
+    let(:asset) { FactoryBot.create(:asset) }
     before do
       asset.permissions_attributes = [{ name: "africana-faculty", access: "read", type: "group" }, { name: "joe_creator", access: "edit", type: "person" }]
       asset.save
     end
     context "Then a registered user" do
-      let(:user) { FactoryGirl.build(:registered_user) }
+      let(:user) { FactoryBot.build(:registered_user) }
 
       it { should_not be_able_to(:discover, asset) }
       it { should_not be_able_to(:read, asset) }
@@ -201,7 +201,7 @@ describe Ability do
     end
 
     context "Then someone whose role/group has read access" do
-      let(:user) { FactoryGirl.build(:martia_morocco) }
+      let(:user) { FactoryBot.build(:martia_morocco) }
       before do
         allow(user).to receive(:groups).and_return(["faculty", "africana-faculty"])
       end
@@ -228,7 +228,7 @@ describe Ability do
         end
       end
     end
-    let(:user) { FactoryGirl.build(:staff) }
+    let(:user) { FactoryBot.build(:staff) }
 
     after do
       Object.send(:remove_const, :MyAbility)
@@ -241,13 +241,13 @@ describe Ability do
   end
 
   describe "calling ability on two separate objects" do
-    let(:asset1) { FactoryGirl.create(:asset) }
-    let(:asset2) { FactoryGirl.create(:asset) }
+    let(:asset1) { FactoryBot.create(:asset) }
+    let(:asset2) { FactoryBot.create(:asset) }
     before do
       asset1.permissions_attributes = [{ name: "registered", access: "read", type: "group" }, { name: "joe_creator", access: "edit", type: "person" }, { name: "calvin_collaborator", access: "edit", type: "person" }]
       asset1.save
     end
-    let(:user) { FactoryGirl.build(:calvin_collaborator) } # has access to @asset1, but not @asset2
+    let(:user) { FactoryBot.build(:calvin_collaborator) } # has access to @asset1, but not @asset2
     after do
       asset1.destroy
       asset2.destroy
@@ -261,8 +261,8 @@ describe Ability do
   end
 
   describe "download permissions" do
-    let(:asset) { FactoryGirl.create(:asset) }
-    let(:user) { FactoryGirl.build(:user) }
+    let(:asset) { FactoryBot.create(:asset) }
+    let(:user) { FactoryBot.build(:user) }
     let(:file) { ActiveFedora::File.new() }
 
     before { allow(file).to receive(:uri).and_return(uri) }

--- a/hydra-access-controls/spec/unit/accessible_by_spec.rb
+++ b/hydra-access-controls/spec/unit/accessible_by_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 describe "active_fedora/accessible_by" do
-  let(:user) {FactoryGirl.build(:ira_instructor)}
+  let(:user) {FactoryBot.build(:ira_instructor)}
   let(:ability) {Ability.new(user)}
-  let(:private_obj) {FactoryGirl.create(:asset)}
-  let(:public_obj) {FactoryGirl.create(:asset)}
-  let(:editable_obj) {FactoryGirl.create(:asset)}
+  let(:private_obj) {FactoryBot.create(:asset)}
+  let(:public_obj) {FactoryBot.create(:asset)}
+  let(:editable_obj) {FactoryBot.create(:asset)}
 
   before do
     private_obj.permissions_attributes = [{ name: "joe_creator", access: "edit", type: "person" }]

--- a/hydra-access-controls/spec/unit/admin_policy_spec.rb
+++ b/hydra-access-controls/spec/unit/admin_policy_spec.rb
@@ -120,7 +120,7 @@ describe Hydra::AdminPolicy do
   # Policy-based Access Controls
   #
   describe "When accessing assets with Policies associated" do
-    let(:user) { FactoryGirl.build(:martia_morocco) }
+    let(:user) { FactoryBot.build(:martia_morocco) }
 
     before do
       allow(user).to receive(:groups).and_return(["faculty", "africana-faculty"])

--- a/hydra-access-controls/spec/unit/permission_spec.rb
+++ b/hydra-access-controls/spec/unit/permission_spec.rb
@@ -62,7 +62,7 @@ describe Hydra::AccessControls::Permission do
 
     context 'with a User instance passed as :name argument' do
       let(:permission) { described_class.new(type: 'person', name: user, access: 'read') }
-      let(:user) { FactoryGirl.build(:archivist, email: 'archivist1@example.com') }
+      let(:user) { FactoryBot.build(:archivist, email: 'archivist1@example.com') }
 
       it "uses string and escape agent when building" do
         expect(permission.agent.first.rdf_subject.to_s).to eq 'http://projecthydra.org/ns/auth/person#archivist1@example.com'

--- a/hydra-access-controls/spec/unit/policy_aware_access_controls_enforcement_spec.rb
+++ b/hydra-access-controls/spec/unit/policy_aware_access_controls_enforcement_spec.rb
@@ -92,7 +92,7 @@ describe Hydra::PolicyAwareAccessControlsEnforcement do
 
   let(:current_ability) { Ability.new(user) }
   subject { PolicyMockSearchBuilder.new(current_ability) }
-  let(:user) { FactoryGirl.build(:sara_student) }
+  let(:user) { FactoryBot.build(:sara_student) }
 
   before do
     @solr_parameters = {}

--- a/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
+++ b/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
@@ -120,12 +120,18 @@ module Hydra
 
       private
 
+      # Previous implementation looped and used response.stream.write, but we
+      # found that had a problem with delay in HTTP response headers being
+      # sent, which this implementation fixed while still streaming.
+      # https://github.com/samvera/hydra-head/pull/421
       def stream_body(iostream)
-        iostream.each do |in_buff|
-          response.stream.write in_buff
+        # see https://github.com/rails/rails/issues/18714#issuecomment-96204444
+        unless response.headers["Last-Modified"] || response.headers["ETag"]
+          Rails.logger.warn("Response may be buffered instead of streaming, best to set a Last-Modified or ETag header")
         end
-      ensure
-        response.stream.close
+
+        render nothing: true
+        response.body = iostream
       end
 
       def default_file

--- a/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
+++ b/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
@@ -125,11 +125,7 @@ module Hydra
         unless response.headers["Last-Modified"] || response.headers["ETag"]
           Rails.logger.warn("Response may be buffered instead of streaming, best to set a Last-Modified or ETag header")
         end
-        iostream.each do |in_buff|
-          response.stream.write in_buff
-        end
-      ensure
-        response.stream.close
+        self.response_body = iostream
       end
 
       def default_file

--- a/hydra-core/hydra-core.gemspec
+++ b/hydra-core/hydra-core.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'hydra-access-controls', version
 
   gem.add_development_dependency 'sqlite3', '~> 1.3'
-  gem.add_development_dependency 'yard', '~> 0.8.7'
   gem.add_development_dependency 'rspec-rails', '~> 3.1'
   gem.add_development_dependency 'factory_girl_rails', '~> 4.2'
 end

--- a/hydra-core/hydra-core.gemspec
+++ b/hydra-core/hydra-core.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'sqlite3', '~> 1.3'
   gem.add_development_dependency 'rspec-rails', '~> 3.1'
-  gem.add_development_dependency 'factory_girl_rails', '~> 4.2'
+  gem.add_development_dependency 'factory_bot_rails', '~> 4.8.2'
 end

--- a/hydra-core/spec/factories.rb
+++ b/hydra-core/spec/factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence :email do |n|
     "person#{n}@example.com"
   end

--- a/hydra-core/spec/models/user_spec.rb
+++ b/hydra-core/spec/models/user_spec.rb
@@ -32,7 +32,7 @@ describe User do
   end
 
   describe "#groups" do
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryBot.create(:user) }
     let(:mock_service) { double }
     before do
       user.group_service = mock_service

--- a/hydra-core/spec/spec_helper.rb
+++ b/hydra-core/spec/spec_helper.rb
@@ -7,7 +7,7 @@ EngineCart.load_application! path
 require 'bundler/setup'
 require 'rspec/rails'
 require 'hydra-core'
-require "factory_girl"
+require "factory_bot"
 require "factories"
 
 if ENV['COVERAGE']

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'solr_wrapper', '~> 0.18'
   s.add_development_dependency 'fcrepo_wrapper', '~> 0.6'
   s.add_development_dependency 'engine_cart', '~> 1.0'
-  s.add_development_dependency 'yard'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'factory_girl_rails'
+  s.add_development_dependency 'factory_bot_rails'
 end

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -48,43 +48,46 @@
 <schema name="Hydra Demo Index" version="1.5">
   <!-- attribute "name" is the name of this schema and is only used for display purposes.
        Applications should change this to reflect the nature of the search collection.
-       version="1.4" is Solr's version number for the schema syntax and semantics.  It should
+       version="1.5" is Solr's version number for the schema syntax and semantics.  It should
        not normally be changed by applications.
        1.0: multiValued attribute did not exist, all fields are multiValued by nature
        1.1: multiValued attribute introduced, false by default
        1.2: omitTermFreqAndPositions attribute introduced, true by default except for text fields.
        1.3: removed optional field compress feature
        1.4: default auto-phrase (QueryParser feature) to off
+       1.5: omitNorms defaults to true for primitive field types (int, float, boolean, string...)
+# TODO 1.6: useDocValuesAsStored defaults to true.
      -->
 
   <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" />
-    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>    
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
     <fieldType name="rand" class="solr.RandomSortField" omitNorms="true"/>
-    
+
     <!-- Default numeric field types.  -->
     <fieldType name="int" class="solr.TrieIntField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0"/>
-    
+
     <!-- trie numeric field types for faster range queries -->
     <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0"/>
-    
+
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
       -->
     <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
     <!-- A Trie based date field for faster date range queries and date faceting. -->
     <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
-    
-    
+    <!-- A DateRange based date field for truly faster date range queries. -->
+    <fieldType name="dateRange" class="solr.DateRangeField"/>
+
     <!-- This point type indexes the coordinates as separate fields (subFields)
       If subFieldType is defined, it references a type, and a dynamic field
-      definition is created matching *___<typename>.  Alternately, if 
+      definition is created matching *___<typename>.  Alternately, if
       subFieldSuffix is defined, that is used to create the subFields.
       Example: if subFieldType="double", then the coordinates would be
         indexed in fields myloc_0___double,myloc_1___double.
@@ -94,17 +97,17 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-    
+
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
     <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
-    
+
     <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
       For more information about this and other Spatial fields new to Solr 4, see:
       http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
     -->
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
       geo="true" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees" />
-    
+
     <fieldType name="text" class="solr.TextField" omitNorms="false">
       <analyzer>
         <tokenizer class="solr.ICUTokenizerFactory"/>
@@ -112,7 +115,7 @@
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- A text field that only splits on whitespace for exact matching of words -->
     <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
@@ -120,7 +123,7 @@
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-        
+
     <!-- single token analyzed text, for sorting.  Punctuation is significant. -->
     <fieldtype name="alphaSort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
       <analyzer>
@@ -129,7 +132,7 @@
         <filter class="solr.TrimFilterFactory" />
       </analyzer>
     </fieldtype>
-    
+
     <!-- A text field with defaults appropriate for English -->
     <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
@@ -144,7 +147,7 @@
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-        
+
     <!-- queries for paths match documents at that path, or in descendent paths -->
     <fieldType name="descendent_path" class="solr.TextField">
       <analyzer type="index">
@@ -154,7 +157,7 @@
         <tokenizer class="solr.KeywordTokenizerFactory" />
       </analyzer>
     </fieldType>
-    
+
     <!-- queries for paths match documents at that path, or in ancestor paths -->
     <fieldType name="ancestor_path" class="solr.TextField">
       <analyzer type="index">
@@ -179,12 +182,12 @@
   <fields>
     <!-- If you remove this field, you must _also_ disable the update log in solrconfig.xml
     or Solr won't start. _version_ and update log are required for SolrCloud
-    --> 
+    -->
     <field name="_version_" type="long" indexed="true" stored="true"/>
-   
+
     <field name="id" type="string" stored="true" indexed="true" multiValued="false" required="true"/>
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
-    
+
     <field name="lat" type="tdouble" stored="true" indexed="true" multiValued="false"/>
     <field name="lng" type="tdouble" stored="true" indexed="true" multiValued="false"/>
 
@@ -201,7 +204,7 @@
     <dynamicField name="*_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tsiv" type="text" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tsimv" type="text" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-    
+
     <!-- English text (_te...) -->
     <dynamicField name="*_tei" type="text_en" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_teim" type="text_en" stored="false" indexed="true" multiValued="true"/>
@@ -213,7 +216,7 @@
     <dynamicField name="*_teimv" type="text_en" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tesiv" type="text_en" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tesimv" type="text_en" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-    
+
     <!-- string (_s...) -->
     <dynamicField name="*_si" type="string" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_sim" type="string" stored="false" indexed="true" multiValued="true"/>
@@ -222,7 +225,7 @@
     <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true"/>
     <dynamicField name="*_ssort" type="alphaSort" stored="false" indexed="true" multiValued="false"/>
-    
+
     <!-- integer (_i...) -->
     <dynamicField name="*_ii" type="int" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_iim" type="int" stored="false" indexed="true" multiValued="true"/>
@@ -230,7 +233,7 @@
     <dynamicField name="*_ism" type="int" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_isi" type="int" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_isim" type="int" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie integer (_it...) (for faster range queries) -->
     <dynamicField name="*_iti" type="tint" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_itim" type="tint" stored="false" indexed="true" multiValued="true"/>
@@ -238,7 +241,7 @@
     <dynamicField name="*_itsm" type="tint" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_itsi" type="tint" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_itsim" type="tint" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- date (_dt...) -->
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z -->
@@ -248,7 +251,7 @@
     <dynamicField name="*_dtsm" type="date" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dtsi" type="date" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dtsim" type="date" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie date (_dtt...) (for faster range queries) -->
     <dynamicField name="*_dtti" type="tdate" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_dttim" type="tdate" stored="false" indexed="true" multiValued="true"/>
@@ -256,7 +259,15 @@
     <dynamicField name="*_dttsm" type="tdate" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dttsi" type="tdate" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dttsim" type="tdate" stored="true" indexed="true" multiValued="true"/>
-    
+
+    <!-- date range (_dr...) (for faster AND better range queries) -->
+    <dynamicField name="*_dri" type="dateRange" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_drim" type="dateRange" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_drs" type="dateRange" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_drsm" type="dateRange" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_drsi" type="dateRange" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_drsim" type="dateRange" stored="true" indexed="true" multiValued="true"/>
+
     <!-- long (_l...) -->
     <dynamicField name="*_li" type="long" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_lim" type="long" stored="false" indexed="true" multiValued="true"/>
@@ -264,7 +275,7 @@
     <dynamicField name="*_lsm" type="long" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_lsi" type="long" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_lsim" type="long" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie long (_lt...) (for faster range queries) -->
     <dynamicField name="*_lti" type="tlong" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_ltim" type="tlong" stored="false" indexed="true" multiValued="true"/>
@@ -272,7 +283,7 @@
     <dynamicField name="*_ltsm" type="tlong" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_ltsi" type="tlong" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ltsim" type="tlong" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- double (_db...) -->
     <dynamicField name="*_dbi" type="double" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbim" type="double" stored="false" indexed="true" multiValued="true"/>
@@ -280,7 +291,7 @@
     <dynamicField name="*_dbsm" type="double" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dbsi" type="double" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbsim" type="double" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie double (_dbt...) (for faster range queries) -->
     <dynamicField name="*_dbti" type="tdouble" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbtim" type="tdouble" stored="false" indexed="true" multiValued="true"/>
@@ -288,7 +299,7 @@
     <dynamicField name="*_dbtsm" type="tdouble" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dbtsi" type="tdouble" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbtsim" type="tdouble" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- float (_f...) -->
     <dynamicField name="*_fi" type="float" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_fim" type="float" stored="false" indexed="true" multiValued="true"/>
@@ -296,7 +307,7 @@
     <dynamicField name="*_fsm" type="float" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_fsi" type="float" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_fsim" type="float" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie float (_ft...) (for faster range queries) -->
     <dynamicField name="*_fti" type="tfloat" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_ftim" type="tfloat" stored="false" indexed="true" multiValued="true"/>
@@ -304,12 +315,12 @@
     <dynamicField name="*_ftsm" type="tfloat" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_ftsi" type="tfloat" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ftsim" type="tfloat" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- boolean (_b...) -->
     <dynamicField name="*_bi" type="boolean" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_bs" type="boolean" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true" multiValued="false"/>
-    
+
     <!-- Type used to index the lat and lon components for the "location" FieldType -->
     <dynamicField name="*_coordinate" type="tdouble" indexed="true"  stored="false" />
 
@@ -329,7 +340,7 @@
 
   </fields>
 
- <!-- Field to use to determine and enforce document uniqueness. 
+ <!-- Field to use to determine and enforce document uniqueness.
       Unless this field is marked with required="false", it will be a required field
    -->
  <uniqueKey>id</uniqueKey>

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -3,7 +3,8 @@ class TestAppGenerator < Rails::Generators::Base
   source_root File.expand_path("../../../../spec/test_app_templates", __FILE__)
 
   def install_blacklight
-    generate 'blacklight:install --devise'
+    # we can skip solr because the activefedora installer will also do it (in the hydra:head generator)
+    generate 'blacklight:install --devise --skip-solr'
   end
 
   # if you need to generate any additional configuration


### PR DESCRIPTION
This PR backports most changes to master since 10.5.0 except ones that I felt might be backwards incompatible.  This is in preparation for cutting a 10.5.1 release.

Commits left out of this pull request:
* Updating to use AF12 (56152a6aa3eba04e4155b7eaf74a317fdd7ec447)
* No need to maintain a configuration. ActiveFedora generates it (667d669c695e5f7ee4390e3d70fccbaa2a5f8a3f)
* Use the new Blacklight::AccessControls::SearchBuilder (84700aa677b2b3fbd8e0c6cffd251a4909603bcc)
* Preparing for 11.0.0.rc1 release (e09a819152f1cf6f96fdff528d4baa9e3ff9d541)

@projecthydra/hydra-contributors
