### PR TITLE
Remove autoload paths

### DIFF
--- a/hydra-access-controls/lib/hydra-access-controls.rb
+++ b/hydra-access-controls/lib/hydra-access-controls.rb
@@ -29,12 +29,7 @@ module Hydra
     alias :config :configure
   end
 
-  class Engine < Rails::Engine
-    # autoload_paths is only necessary for Rails 3
-    config.autoload_paths += %W(
-      #{config.root}/app/models/concerns
-    )
-  end
+  class Engine < Rails::Engine; end
 
   # This error is raised when a user isn't allowed to access a given controller action.
   # This usually happens within a call to AccessControlsEnforcement#enforce_access_controls but can be


### PR DESCRIPTION
They were only required for Rails 3 which is no longer supported.