### PR TITLE
hydra-access-controls 10.x is not compatible with blacklight-access_controls 0.7

### DIFF
--- a/hydra-access-controls/hydra-access-controls.gemspec
+++ b/hydra-access-controls/hydra-access-controls.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'cancancan', '~> 1.8'
   gem.add_dependency 'deprecation', '~> 1.0'
   gem.add_dependency "blacklight", '>= 5.16'
-  gem.add_dependency "blacklight-access_controls", '~> 0.6'
+  gem.add_dependency "blacklight-access_controls", '~> 0.6.0'
 
   gem.add_development_dependency "rake", '~> 10.1'
   gem.add_development_dependency 'rspec', '~> 3.1'


### PR DESCRIPTION
This is leading to a RuntimeError on nurax:
>You may not use Blacklight::AccessControls::SearchBuilder and include Blacklight::AccessControls::Enforcement on SearchBuilder at the same time

@samvera/hydra-head
