### PR TITLE
Integrating support for Coveralls and restructuring the integration of SimpleCov

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/hydra-access-controls/hydra-access-controls.gemspec
+++ b/hydra-access-controls/hydra-access-controls.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'activesupport', '>= 4', '< 6'
   gem.add_dependency "active-fedora", '>= 10.0.0', '< 13'
-  gem.add_dependency 'cancancan', '~> 1.8'
-  gem.add_dependency 'deprecation', '~> 1.0'
   gem.add_dependency "blacklight", '>= 5.16'
   gem.add_dependency "blacklight-access_controls", '~> 0.6.0'
+  gem.add_dependency 'cancancan', '~> 1.8'
+  gem.add_dependency 'deprecation', '~> 1.0'
 
   gem.add_development_dependency "rake", '~> 10.1'
   gem.add_development_dependency 'rspec', '~> 3.1'

--- a/hydra-access-controls/spec/spec_helper.rb
+++ b/hydra-access-controls/spec/spec_helper.rb
@@ -11,12 +11,22 @@ Hydra::Engine.config.autoload_paths.each { |path| $LOAD_PATH.unshift path }
 
 require 'byebug' unless ENV['CI']
 
-if ENV['COVERAGE'] and RUBY_VERSION =~ /^1.9/
-  require 'simplecov'
-  require 'simplecov-rcov'
+def coverage_needed?
+  ENV['COVERAGE'] || ENV['TRAVIS']
+end
 
-  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-  SimpleCov.start
+if RUBY_VERSION =~ /^1.9/ && coverage_needed?
+  require 'simplecov'
+  require 'coveralls'
+
+  SimpleCov.root(File.expand_path('../../../', __FILE__))
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+    [
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+    ]
+  )
+  SimpleCov.start('rails')
 end
 
 # Since we're not doing a Rails Engine test, we have to load these classes manually:
@@ -52,4 +62,3 @@ RSpec.configure do |config|
     ActiveFedora::Cleaner.clean!
   end
 end
-

--- a/hydra-core/hydra-core.gemspec
+++ b/hydra-core/hydra-core.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_dependency "railties", '>= 4.0.0', '< 6'
   gem.add_dependency 'hydra-access-controls', version
+  gem.add_dependency "railties", '>= 4.0.0', '< 6'
 
-  gem.add_development_dependency 'sqlite3', '~> 1.3'
-  gem.add_development_dependency 'rspec-rails', '~> 3.1'
-  gem.add_development_dependency 'rails-controller-testing', '~> 1'
   gem.add_development_dependency 'factory_bot_rails', '~> 4.8.2'
+  gem.add_development_dependency 'rails-controller-testing', '~> 1'
+  gem.add_development_dependency 'rspec-rails', '~> 3.1'
+  gem.add_development_dependency 'sqlite3', '~> 1.3'
 end

--- a/hydra-core/spec/spec_helper.rb
+++ b/hydra-core/spec/spec_helper.rb
@@ -10,12 +10,22 @@ require 'hydra-core'
 require "factory_bot"
 require "factories"
 
-if ENV['COVERAGE']
-  require 'simplecov'
-  require 'simplecov-rcov'
+def coverage_needed?
+  ENV['COVERAGE'] || ENV['TRAVIS']
+end
 
-  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-  SimpleCov.start
+if coverage_needed?
+  require 'simplecov'
+  require 'coveralls'
+
+  SimpleCov.root(File.expand_path('../../../', __FILE__))
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+    [
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+    ]
+  )
+  SimpleCov.start('rails')
 end
 
 ActiveFedora::Base.logger = Logger.new(STDOUT)

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -16,13 +16,15 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency 'rails', '>= 3.2.6'
   s.add_dependency 'hydra-access-controls', version
   s.add_dependency 'hydra-core', version
+  s.add_dependency 'rails', '>= 3.2.6'
 
-  s.add_development_dependency 'solr_wrapper', '~> 0.18'
-  s.add_development_dependency 'fcrepo_wrapper', '~> 0.6'
+  s.add_development_dependency 'coveralls'
   s.add_development_dependency 'engine_cart', '~> 1.0'
-  s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'factory_bot_rails'
+  s.add_development_dependency 'fcrepo_wrapper', '~> 0.6'
+  s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'solr_wrapper', '~> 0.18'
 end


### PR DESCRIPTION
Forward port of #457 now that master has been rolled back to the 10.x line. 

This is an alternative to #458.  
Resolves #448.

@samvera/hydra-head