### PR TITLE
Update jettywrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
   - 2.2
   - 2.1
-  - 2.0
 
 gemfile:
   - gemfiles/gemfile.rails42

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ Bundler::GemHelper.install_tasks
 
 APP_ROOT= File.dirname(__FILE__)
 require 'jettywrapper'
+Jettywrapper.hydra_jetty_version = 'v7.0.0'
 
 namespace :jetty do
   TEMPLATE_DIR = 'hydra-core/lib/generators/hydra/templates'
@@ -17,10 +18,10 @@ namespace :jetty do
     Rake::Task["jetty:config_solr"].reenable
     Rake::Task["jetty:config_solr"].invoke
   end
-  
+
   desc "Copies the default SOLR config for the bundled Hydra Testing Server"
   task :config_solr do
-    FileList["#{SOLR_DIR}/*"].each do |f|  
+    FileList["#{SOLR_DIR}/*"].each do |f|
       cp("#{f}", 'jetty/solr/development-core/conf/', :verbose => true)
       cp("#{f}", 'jetty/solr/test-core/conf/', :verbose => true)
     end
@@ -29,13 +30,13 @@ namespace :jetty do
 
   desc "Copies a custom fedora config for the bundled Hydra Testing Server"
   task :config_fedora do
-    # load a custom fedora.fcfg - 
+    # load a custom fedora.fcfg -
     if defined?(Rails.root)
       app_root = Rails.root
     else
       app_root = File.join(File.dirname(__FILE__),"..")
     end
-     
+
     fcfg = File.join(FEDORA_DIR,"development","fedora.fcfg")
     if File.exists?(fcfg)
       puts "copying over development/fedora.fcfg"
@@ -63,7 +64,7 @@ task :ci => ['jetty:config'] do
   raise "test failures: #{error}" if error
 
   Rake::Task["doc"].invoke
-  
+
 
 end
 
@@ -175,7 +176,7 @@ def all_modules(cmd)
   FRAMEWORKS.each do |dir|
     Dir.chdir(dir) do
       puts "\n\e[1;33m[Hydra CI] #{dir}\e[m\n"
-      #cmd = "bundle exec rake spec" # doesn't work because it doesn't require the gems specified in the Gemfiles of the test rails apps 
+      #cmd = "bundle exec rake spec" # doesn't work because it doesn't require the gems specified in the Gemfiles of the test rails apps
       return false unless system(cmd)
     end
   end
@@ -186,7 +187,7 @@ begin
   require 'yard/rake/yardoc_task'
   project_root = File.expand_path(".")
   doc_destination = File.join(project_root, 'doc')
-  if !File.exists?(doc_destination) 
+  if !File.exists?(doc_destination)
     FileUtils.mkdir_p(doc_destination)
   end
 

--- a/hydra-core/hydra-core.gemspec
+++ b/hydra-core/hydra-core.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rails", '~> 4.0'
   gem.add_dependency 'block_helpers'
   gem.add_dependency 'hydra-access-controls', version
-  gem.add_dependency 'jettywrapper', "~> 1.5"
-  
+  gem.add_dependency 'jettywrapper', "~> 2.0"
+
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'yard'
   gem.add_development_dependency 'rspec-rails'

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files = ['lib/hydra/head.rb']
   s.require_paths = ["lib"]
   s.license = "APACHE2"
-    
+
 
   s.required_ruby_version = '>= 2.0.0'
 
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
   s.add_dependency('hydra-access-controls', version)
   s.add_dependency('hydra-core', version)
 
-  s.add_development_dependency "jettywrapper", '~> 1.5'
-  s.add_development_dependency "yard" 
+  s.add_development_dependency "jettywrapper", '~> 2.0'
+  s.add_development_dependency "yard"
 
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'factory_girl_rails'


### PR DESCRIPTION
The 1.x version of jettywrapper depends on logger 1.3, which uses Ruby 2.3 syntax.  The 2.0 version of jettywrapper does not have a logger dependency and thus can be used with older rubies.