### PR TITLE
Drop support of ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
   - 2.2
   - 2.1
-  - 2.0
 
 gemfile:
   - gemfiles/gemfile.rails42


### PR DESCRIPTION
Turbolinks is not compatible with ruby 2.0 and causes:
```
/home/travis/.rvm/gems/ruby-2.0.0-p648/gems/turbolinks-5.2.0/lib/turbolinks.rb:25:in `block (2 levels) in <class:Engine>': private method `include' called for ActionDispatch::Assertions:Module
```

Ruby 2.0 has been EOL for well over 2 years.
