### PR TITLE
Use [* TO *] to work with old and new versions of AF and Solr

### DIFF
--- a/hydra-access-controls/app/services/hydra/embargo_service.rb
+++ b/hydra-access-controls/app/services/hydra/embargo_service.rb
@@ -14,7 +14,7 @@ module Hydra
       #   (assumes that when lease visibility is applied to assets
       #    whose leases have expired, the lease expiration date will be removed from its metadata)
       def assets_under_embargo
-        ActiveFedora::Base.where("#{Hydra.config.permissions.embargo.release_date}:*")
+        ActiveFedora::Base.where("#{Hydra.config.permissions.embargo.release_date}:[* TO *]")
       end
 
       # Returns all assets that have had embargoes deactivated in the past.

--- a/hydra-access-controls/app/services/hydra/lease_service.rb
+++ b/hydra-access-controls/app/services/hydra/lease_service.rb
@@ -10,7 +10,7 @@ module Hydra
       #   (assumes that when lease visibility is applied to assets
       #    whose leases have expired, the lease expiration date will be removed from its metadata)
       def assets_under_lease
-        ActiveFedora::Base.where("#{Hydra.config.permissions.lease.expiration_date}:*")
+        ActiveFedora::Base.where("#{Hydra.config.permissions.lease.expiration_date}:[* TO *]")
       end
 
       # Returns all assets that have had embargoes deactivated in the past.
@@ -20,4 +20,3 @@ module Hydra
     end
   end
 end
-

--- a/hydra-access-controls/spec/services/embargo_service_spec.rb
+++ b/hydra-access-controls/spec/services/embargo_service_spec.rb
@@ -29,7 +29,6 @@ describe Hydra::EmbargoService do
 
   describe "#assets_under_embargo" do
     it "returns all assets with embargo release date set" do
-      result = subject.assets_under_embargo
       returned_ids = subject.assets_under_embargo.map {|a| a.id}
       expect(returned_ids).to include work_with_expired_embargo1.id, work_with_expired_embargo2.id, work_with_embargo_in_effect.id
       expect(returned_ids).to_not include work_without_embargo.id


### PR DESCRIPTION
ActiveFedora 12.1.0 brings a new solr schema which switches from the deprecated solr.TrieDateField (to be removed in solr 8) to solr.DatePointField. While the TrieDateField allowed queries like date_dtsi:*, DatePointField only allows single value and range queries so this example query needs to change to date_dtsi:[* TO *]. Luckily the latter also works in TrieDateField. This PR updates both the embargo and lease search builders to use the [* TO *] query to work with both types of solr fields.

@samvera/hydra-head
