### PR TITLE
Use standard active-fedora ci strategy

### DIFF
--- a/hydra-access-controls/tasks/hydra-access-controls.rake
+++ b/hydra-access-controls/tasks/hydra-access-controls.rake
@@ -1,15 +1,12 @@
 namespace "hydra-access" do
-  desc "Run Continuous Integration"
-  task :ci do
-    ENV['environment'] = "test"
-    solr_params = { port: 8985, verbose: true, managed: true }
-    fcrepo_params = { port: 8986, verbose: true, managed: true,
-                      no_jms: true, fcrepo_home_dir: 'fcrepo4-test-data' }
-    SolrWrapper.wrap(solr_params) do |solr|
-      solr.with_collection(name: 'hydra-test', dir: File.join(File.expand_path("../..", File.dirname(__FILE__)), "solr", "config")) do
-        FcrepoWrapper.wrap(fcrepo_params) do
-          Rake::Task['spec'].invoke
-        end
+  task ci: ['spec_with_server']
+
+  unless Rails.env.production?
+    require 'solr_wrapper/rake_task'
+
+    task :spec_with_server do
+      with_server 'test' do
+        Rake::Task['spec'].invoke
       end
     end
   end


### PR DESCRIPTION
Instead of configuring a custom fedora and solr setup, use the standard
active-fedora test strategy that most samvera builds are using these
days.

If we can be consistent with how we do our builds it will reduce confusion and allow us to configure active_fedora to match blacklight in how it sets up the config directory. See https://github.com/samvera/active_fedora/pull/1294

@samvera/hydra-head
