### PR TITLE
Revert "Bump Blacklight-access_controls to 6.0"

### DIFF
--- a/hydra-access-controls/hydra-access-controls.gemspec
+++ b/hydra-access-controls/hydra-access-controls.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'activesupport', '>= 4', '< 6'
   gem.add_dependency "active-fedora", '>= 10.0.0', '< 13'
-  gem.add_dependency "blacklight", '>= 5.16', '< 7'
-  gem.add_dependency "blacklight-access_controls", '~> 6.0'
+  gem.add_dependency "blacklight", '>= 5.16'
+  gem.add_dependency "blacklight-access_controls", '~> 0.6.0'
   gem.add_dependency 'cancancan', '~> 1.8'
   gem.add_dependency 'deprecation', '~> 1.0'
 

--- a/hydra-access-controls/lib/active_fedora/accessible_by.rb
+++ b/hydra-access-controls/lib/active_fedora/accessible_by.rb
@@ -1,5 +1,8 @@
 ActiveFedora::QueryMethods.module_eval do
   extend ActiveSupport::Concern
+  included do
+    include Hydra::AccessControlsEnforcement
+  end
 
   def accessible_by(ability, action = :index)
     permission_types = case action
@@ -8,8 +11,7 @@ ActiveFedora::QueryMethods.module_eval do
       when :update, :edit, :create, :new, :destroy then [:edit]
     end
 
-    builder = Hydra::SearchBuilder.new(nil, ability: ability, permission_types: permission_types)
-    filters = builder.send(:gated_discovery_filters).join(" OR ")
+    filters = gated_discovery_filters(permission_types, ability).join(" OR ")
     spawn.where!(filters)
   end
 end

--- a/hydra-access-controls/lib/hydra/access_controls_enforcement.rb
+++ b/hydra-access-controls/lib/hydra/access_controls_enforcement.rb
@@ -1,5 +1,6 @@
 module Hydra::AccessControlsEnforcement
   extend ActiveSupport::Concern
+  include Blacklight::AccessControls::Enforcement
 
   protected
 

--- a/hydra-access-controls/lib/hydra/policy_aware_access_controls_enforcement.rb
+++ b/hydra-access-controls/lib/hydra/policy_aware_access_controls_enforcement.rb
@@ -32,7 +32,7 @@ module Hydra::PolicyAwareAccessControlsEnforcement
   # @param [Array{String,#to_sym}] permission_types symbols (or equivalent) from Hydra.config.permissions.inheritable
   def apply_policy_group_permissions(permission_types = discovery_permissions)
       user_access_filters = []
-      ability.user_groups.each_with_index do |group, i|
+      current_ability.user_groups.each_with_index do |group, i|
         permission_types.each do |type|
           user_access_filters << escape_filter(Hydra.config.permissions.inheritable[type.to_sym].group, group)
         end
@@ -43,7 +43,7 @@ module Hydra::PolicyAwareAccessControlsEnforcement
   # for individual user access
   # @param [Array{String,#to_sym}] permission_types
   def apply_policy_user_permissions(permission_types = discovery_permissions)
-    user = ability.current_user
+    user = current_ability.current_user
     return [] unless user && user.user_key.present?
     permission_types.map do |type|
       escape_filter(Hydra.config.permissions.inheritable[type.to_sym].individual, user.user_key)

--- a/hydra-access-controls/spec/unit/policy_aware_access_controls_enforcement_spec.rb
+++ b/hydra-access-controls/spec/unit/policy_aware_access_controls_enforcement_spec.rb
@@ -1,15 +1,28 @@
 require 'spec_helper'
 
-RSpec.describe Hydra::PolicyAwareAccessControlsEnforcement do
+describe Hydra::PolicyAwareAccessControlsEnforcement do
   before do
     allow(Devise).to receive(:authentication_keys).and_return(['uid'])
 
-    class PolicyMockSearchBuilder < Hydra::SearchBuilder
+    class PolicyMockSearchBuilder < Blacklight::SearchBuilder
+      include Blacklight::Solr::SearchBuilderBehavior
+      include Hydra::AccessControlsEnforcement
       include Hydra::PolicyAwareAccessControlsEnforcement
+      attr_accessor :params
+
+      def initialize(current_ability)
+        @current_ability = current_ability
+      end
+
+      def current_ability
+        @current_ability
+      end
+
+      def session
+      end
 
       delegate :logger, to: :Rails
     end
-
     @sample_policies = []
     # user discover
     policy1 = Hydra::AdminPolicy.create(id: "test-policy1")
@@ -78,7 +91,7 @@ RSpec.describe Hydra::PolicyAwareAccessControlsEnforcement do
   end
 
   let(:current_ability) { Ability.new(user) }
-  subject { PolicyMockSearchBuilder.new(nil, ability: current_ability) }
+  subject { PolicyMockSearchBuilder.new(current_ability) }
   let(:user) { FactoryBot.build(:sara_student) }
 
   before do
@@ -121,7 +134,7 @@ RSpec.describe Hydra::PolicyAwareAccessControlsEnforcement do
 
     context "when policies are included" do
       before { subject.apply_gated_discovery(@solr_parameters) }
-
+      
       it "builds a query that includes all the policies" do
         skip if ActiveFedora.version.split('.').first.to_i < 11
         (1..11).each do |p|
@@ -129,7 +142,7 @@ RSpec.describe Hydra::PolicyAwareAccessControlsEnforcement do
         end
       end
     end
-
+    
     context "when policies are not included" do
       before do
         allow(subject).to receive(:policy_clauses).and_return(nil)

--- a/hydra-core/app/controllers/concerns/hydra/catalog.rb
+++ b/hydra-core/app/controllers/concerns/hydra/catalog.rb
@@ -20,9 +20,4 @@ module Hydra::Catalog
 
     permissions_doc
   end
-
-  # This overrides the method in Blacklight::AccessControls::Catalog
-  def search_builder
-    Hydra::SearchBuilder.new(self, ability: current_ability)
-  end
 end

--- a/hydra-core/app/models/hydra/search_builder.rb
+++ b/hydra-core/app/models/hydra/search_builder.rb
@@ -1,6 +1,0 @@
-module Hydra
-  class SearchBuilder < Blacklight::AccessControls::SearchBuilder
-    # Add a filter query to restrict the search to documents the current user has access to
-    include Hydra::AccessControlsEnforcement
-  end
-end

--- a/hydra-core/lib/generators/hydra/head_generator.rb
+++ b/hydra-core/lib/generators/hydra/head_generator.rb
@@ -49,6 +49,14 @@ module Hydra
       end
     end
 
+    # Add Hydra to the SearchBuilder
+    def inject_hydra_search_builder_behavior
+      insert_into_file "app/models/search_builder.rb", after: "include Blacklight::Solr::SearchBuilderBehavior\n" do
+        "  # Add a filter query to restrict the search to documents the current user has access to\n" \
+        "  include Hydra::AccessControlsEnforcement\n"
+      end
+    end
+
     # Copy all files in templates/config directory to host config
     def create_configuration_files
 
@@ -71,7 +79,7 @@ module Hydra
     def create_conneg_configuration
       file_path = "config/initializers/mime_types.rb"
       append_to_file file_path do
-        "Mime::Type.register \"application/n-triples\", :nt\n" +
+        "Mime::Type.register \"application/n-triples\", :nt\n" + 
         "Mime::Type.register \"application/ld+json\", :jsonld\n" +
         "Mime::Type.register \"text/turtle\", :ttl"
       end
@@ -81,7 +89,7 @@ module Hydra
       file_path = "app/models/solr_document.rb"
       if File.exists?(file_path)
         inject_into_file file_path, :before => /end\Z/ do
-          "\n  # Do content negotiation for AF models. \n" +
+          "\n  # Do content negotiation for AF models. \n" + 
           "\n  use_extension( Hydra::ContentNegotiation )\n"
         end
       end

--- a/hydra-core/spec/search_builders/search_builder_spec.rb
+++ b/hydra-core/spec/search_builders/search_builder_spec.rb
@@ -1,13 +1,14 @@
 require 'spec_helper'
 
-RSpec.describe Hydra::SearchBuilder do
-  let(:context) { CatalogController.new }
+describe SearchBuilder do
+  let(:processor_chain) { [:add_access_controls_to_solr_params] }
+  let(:context) { double('context') }
   let(:user) { double('user', user_key: 'joe') }
   let(:current_ability) { double('ability', user_groups: [], current_user: user) }
   let(:search_builder) { described_class }
 
   subject do
-    search_builder.new(context, ability: current_ability)
+    search_builder.new(processor_chain, context)
   end
 
   it "extends classes with the necessary Hydra modules" do
@@ -16,7 +17,7 @@ RSpec.describe Hydra::SearchBuilder do
 
   context "when a query is generated" do
     it "triggers add_access_controls_to_solr_params" do
-      expect(subject).to receive(:apply_gated_discovery)
+      expect(subject).to receive(:add_access_controls_to_solr_params)
       subject.query
     end
   end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -5,7 +5,6 @@ class TestAppGenerator < Rails::Generators::Base
   def install_blacklight
     # we can skip solr because the activefedora installer will also do it (in the hydra:head generator)
     generate 'blacklight:install --devise --skip-solr'
-    gem 'rsolr', '>= 1.0', '< 3'
   end
 
   # if you need to generate any additional configuration


### PR DESCRIPTION
Reverts samvera/hydra-head#475
I think this PR introduced backwards incompatible changes that break existing applications (and I believe is untested against those apps).  I'm not ready to resolve this yet or make a 11.0 release so I'd like to revert this for now.