### PR TITLE
Build permission relations, drop old rubies/rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ else
   end
 
   case ENV['RAILS_VERSION']
+  when /^5.[12]/
+    gem 'sass-rails', '~> 5.0'
   when /^4.2/
     gem 'responders', '~> 2.0'
     gem 'sass-rails', '>= 5.0'

--- a/hydra-access-controls/app/models/hydra/access_control.rb
+++ b/hydra-access-controls/app/models/hydra/access_control.rb
@@ -31,7 +31,7 @@ module Hydra
             obj.update(attributes.except(:id, '_destroy'))
           end
         else
-          relationship.create(attributes)
+          relationship.build(attributes)
         end
       end
       # Poison the cache

--- a/hydra-access-controls/app/models/hydra/access_control.rb
+++ b/hydra-access-controls/app/models/hydra/access_control.rb
@@ -35,7 +35,7 @@ module Hydra
         end
       end
       # Poison the cache
-      relationship.reset if any_destroyed
+      save! && relationship.reset if any_destroyed
     end
 
     def relationship

--- a/hydra-core/hydra-core.gemspec
+++ b/hydra-core/hydra-core.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'hydra-access-controls', version
   gem.add_dependency "railties", '>= 4.0.0', '< 6'
+  gem.add_dependency 'sass-rails', '~> 5.0'
 
   gem.add_development_dependency 'rails-controller-testing', '~> 1'
   gem.add_development_dependency 'rspec-rails', '~> 3.1'

--- a/hydra-core/hydra-core.gemspec
+++ b/hydra-core/hydra-core.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'hydra-access-controls', version
   gem.add_dependency "railties", '>= 4.0.0', '< 6'
-  gem.add_dependency 'sass-rails', '~> 5.0'
 
   gem.add_development_dependency 'rails-controller-testing', '~> 1'
   gem.add_development_dependency 'rspec-rails', '~> 3.1'

--- a/hydra-core/hydra-core.gemspec
+++ b/hydra-core/hydra-core.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = version
   gem.license       = "APACHE2"
 
-  gem.required_ruby_version = '>= 1.9.3'
+  gem.required_ruby_version = '>= 2.4'
 
   gem.add_dependency 'hydra-access-controls', version
   gem.add_dependency "railties", '>= 4.0.0', '< 6'

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.license       = 'APACHE-2.0'
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'hydra-access-controls', version
   s.add_dependency 'hydra-core', version
-  s.add_dependency 'rails', '>= 3.2.6'
+  s.add_dependency 'rails', '>= 5'
 
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'engine_cart', '~> 2.2'


### PR DESCRIPTION
Fixes #500 ; refs samvera/hyrax#3974

`build` a permission object when setting permissions_attributes instead of using `create`.
Fixes Circle build with sprockets 4.0 workaround.
Removes old versions of ruby and rails as per #500 

A past commit (a5c4dd58001a961074395cafee09f496ddc39fdb) changed the creation of an AccessControl from using `create` to using `build` to avoid orphan objects. That change caused hyrax to be unable to create a work when also adding user/group permissions, resulting in a 'no agent' error.

It appears this is caused by the AccessControl not being saved correctly, or thinking it has not changed since being persisted, when triggered by saving the work object. Changing the permission relationship `create` to `build` avoids this issue and may further reduce the number of orphaned objects.

This change did cause a spec fail, specifically when permission deletions and creations/updates are combined in a single assignment. This is fixed by explicitly saving before poisoning the cache in the case of deleted permissions.

Changes proposed in this pull request:
* Build permissions relations instead of creating them
* Always save after deleting permissions but before resetting the cache.
* Drop old rubies and rails versions.

@samvera/hydra-head
