### PR TITLE
Support ruby 2.7 and drop support for rails 5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,44 +57,18 @@ workflows:
   ci:
     jobs:
       - bundle_and_test:
+          name: "ruby2-7_rails5.2"
+          ruby_version: 2.7.0
+          rails_version: 5.2.4.1
+      - bundle_and_test:
           name: "ruby2-6_rails5.2"
           ruby_version: 2.6.3
-          rails_version: 5.2.3
-      - bundle_and_test:
-          name: "ruby2-6_rails5.1"
-          ruby_version: 2.6.3
-          rails_version: 5.1.7
-      - bundle_and_test:
-          name: "ruby2-6_rails5.1_AF11"
-          ruby_version: 2.6.3
-          rails_version: 5.1.7
-          active_fedora_version: '~>11.5'
-          solr_config_path: '.internal_test_app/solr/config'
+          rails_version: 5.2.4.1
       - bundle_and_test:
           name: "ruby2-5_rails5.2"
           ruby_version: 2.5.5
-          rails_version: 5.2.3
-      - bundle_and_test:
-          name: "ruby2-5_rails5.1"
-          ruby_version: 2.5.5
-          rails_version: 5.1.7
-      - bundle_and_test:
-          name: "ruby2-5_rails5.1_AF11"
-          ruby_version: 2.5.5
-          rails_version: 5.1.7
-          active_fedora_version: '~>11.5'
-          solr_config_path: '.internal_test_app/solr/config'
+          rails_version: 5.2.4.1
       - bundle_and_test:
           name: "ruby2-4_rails5.2"
           ruby_version: 2.4.6
-          rails_version: 5.2.3
-      - bundle_and_test:
-          name: "ruby2-4_rails5.1"
-          ruby_version: 2.4.6
-          rails_version: 5.1.7
-      - bundle_and_test:
-          name: "ruby2-4_rails5.1_AF11"
-          ruby_version: 2.4.6
-          rails_version: 5.1.7
-          active_fedora_version: '~>11.5'
-          solr_config_path: '.internal_test_app/solr/config'
+          rails_version: 5.2.4.1

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'hydra-access-controls', version
   s.add_dependency 'hydra-core', version
-  s.add_dependency 'rails', '>= 5'
+  s.add_dependency 'rails', '>= 5.2', '< 6.1'
 
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'engine_cart', '~> 2.2'


### PR DESCRIPTION
Fixes #503 .  Support for Rails 6 (#504) depends on an upgrade of blacklight so that is a larger task.  Maybe it makes sense to try and do that before release too?

@samvera/hydra-head
