### PR TITLE
Adding Ruby 2.7.z and Rails 6.y.z releases to the CircleCI build configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,44 +57,74 @@ workflows:
   ci:
     jobs:
       - bundle_and_test:
+          name: "ruby2-7_rails6.0"
+          ruby_version: 2.7.0
+          rails_version: 6.0.2
+      - bundle_and_test:
+          name: "ruby2-7_rails5.2"
+          ruby_version: 2.7.0
+          rails_version: 5.2.3
+      - bundle_and_test:
+          name: "ruby2-7_rails5.1"
+          ruby_version: 2.7.0
+          rails_version: 5.1.7
+      - bundle_and_test:
+          name: "ruby2-7_rails5.1_AF11"
+          ruby_version: 2.7.0
+          rails_version: 5.1.7
+          active_fedora_version: '~>11.5'
+          solr_config_path: '.internal_test_app/solr/config'
+      - bundle_and_test:
+          name: "ruby2-6_rails6.0"
+          ruby_version: 2.6.5
+          rails_version: 6.0.2
+      - bundle_and_test:
           name: "ruby2-6_rails5.2"
-          ruby_version: 2.6.3
+          ruby_version: 2.6.5
           rails_version: 5.2.3
       - bundle_and_test:
           name: "ruby2-6_rails5.1"
-          ruby_version: 2.6.3
+          ruby_version: 2.6.5
           rails_version: 5.1.7
       - bundle_and_test:
           name: "ruby2-6_rails5.1_AF11"
-          ruby_version: 2.6.3
+          ruby_version: 2.6.5
           rails_version: 5.1.7
           active_fedora_version: '~>11.5'
           solr_config_path: '.internal_test_app/solr/config'
       - bundle_and_test:
+          name: "ruby2-5_rails6.0"
+          ruby_version: 2.5.7
+          rails_version: 6.0.2
+      - bundle_and_test:
           name: "ruby2-5_rails5.2"
-          ruby_version: 2.5.5
+          ruby_version: 2.5.7
           rails_version: 5.2.3
       - bundle_and_test:
           name: "ruby2-5_rails5.1"
-          ruby_version: 2.5.5
+          ruby_version: 2.5.7
           rails_version: 5.1.7
       - bundle_and_test:
           name: "ruby2-5_rails5.1_AF11"
-          ruby_version: 2.5.5
+          ruby_version: 2.5.7
           rails_version: 5.1.7
           active_fedora_version: '~>11.5'
           solr_config_path: '.internal_test_app/solr/config'
       - bundle_and_test:
+          name: "ruby2-4_rails6.0"
+          ruby_version: 2.4.9
+          rails_version: 6.0.2
+      - bundle_and_test:
           name: "ruby2-4_rails5.2"
-          ruby_version: 2.4.6
+          ruby_version: 2.4.9
           rails_version: 5.2.3
       - bundle_and_test:
           name: "ruby2-4_rails5.1"
-          ruby_version: 2.4.6
+          ruby_version: 2.4.9
           rails_version: 5.1.7
       - bundle_and_test:
           name: "ruby2-4_rails5.1_AF11"
-          ruby_version: 2.4.6
+          ruby_version: 2.4.9
           rails_version: 5.1.7
           active_fedora_version: '~>11.5'
           solr_config_path: '.internal_test_app/solr/config'


### PR DESCRIPTION
Resolves #503 and #504 