### PR TITLE
Test for inclusion instead of equality to allow for different ordering

### DIFF
--- a/hydra-access-controls/spec/unit/accessible_by_spec.rb
+++ b/hydra-access-controls/spec/unit/accessible_by_spec.rb
@@ -23,7 +23,7 @@ describe "active_fedora/accessible_by" do
 
   describe "#accsesible_by" do
     it "should return objects readable by the ability" do
-      expect(ModsAsset.accessible_by(ability)).to eq [public_obj, editable_obj]
+      expect(ModsAsset.accessible_by(ability)).to contain_exactly(public_obj, editable_obj)
     end
     it "should return object editable by the ability" do
       expect(ModsAsset.accessible_by(ability, :edit)).to eq [editable_obj]


### PR DESCRIPTION
Testing equality was causing this test to fail whenever the search results returned the objects in a different order than expected.  The ordering is not important for this feature so switching to inclusion avoids the intermittently failing test.

Fixes #506.
@samvera/hydra-head
