### PR TITLE
Bump required ruby version to 2.4 to match hydra-head and hydra-core

### DIFF
--- a/hydra-access-controls/hydra-access-controls.gemspec
+++ b/hydra-access-controls/hydra-access-controls.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = version
   gem.license       = "APACHE-2.0"
 
-  gem.required_ruby_version = '>= 1.9.3'
+  gem.required_ruby_version = '>= 2.4'
 
   gem.add_dependency 'activesupport', '>= 4', '< 6'
   gem.add_dependency "active-fedora", '>= 10.0.0'
@@ -25,6 +25,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'cancancan', '~> 1.8'
   gem.add_dependency 'deprecation', '~> 1.0'
 
-  gem.add_development_dependency "rake", '~> 10.1'
+  gem.add_development_dependency "rake", '~> 12.3', '>= 12.3.3'
   gem.add_development_dependency 'rspec', '~> 3.1'
 end


### PR DESCRIPTION
Also Bump version of rake to 12.3.3 for security patch

hydra-access-controls should have switched to requiring ruby 2.4+ like its parent and sibling gems when 11.0.0 was released but it was overlooked.

@samvera/hydra-head
