### PR TITLE
Visibility dirty tracking

### DIFF
--- a/hydra-access-controls/spec/unit/embargoable_spec.rb
+++ b/hydra-access-controls/spec/unit/embargoable_spec.rb
@@ -213,7 +213,11 @@ describe Hydra::AccessControls::Embargoable do
       before do
         subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
         # reset the changed log
-        subject.send(:instance_variable_set, :@visibility_will_change, false)
+        if ActiveModel.version < Gem::Version.new('4.2.0')
+          subject.send(:reset_changes)
+        else
+          subject.send(:clear_changes_information)
+        end
       end
 
       it "applies appropriate embargo_visibility settings" do

--- a/hydra-access-controls/spec/unit/visibility_spec.rb
+++ b/hydra-access-controls/spec/unit/visibility_spec.rb
@@ -100,4 +100,29 @@ describe Hydra::AccessControls::Visibility do
       expect(model.read_groups).to contain_exactly 'public', 'another'
     end
   end
+
+  context 'dirty tracking' do
+    let(:object_class) do
+      Class.new(ActiveFedora::Base) do
+        include Hydra::AccessControls::Permissions
+      end
+    end
+
+    before { stub_const("Foo", object_class) }
+
+    subject { Foo.new }
+
+    it 'responds to visibility_changed?' do
+      expect(subject).to respond_to(:visibility_changed?)
+    end
+
+    it 'tracks changes' do
+      expect(subject.visibility_changed?).to eq false
+      subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      expect(subject.visibility_changed?).to eq true
+      expect(subject.visibility_changed?(to: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)).to eq true
+      expect(subject.visibility_changed?(from: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE)).to eq true
+      expect(subject.visibility_changed?(from: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, to: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)).to eq true
+    end
+  end
 end


### PR DESCRIPTION
Prior to this PR, dirty tracking of visibility was implemented in a limited, custom way.  `#visibility_changed?` with no arguments was the only method implemented.  Switching to ActiveModel::Dirty makes dirty tracking support more standard and with more available methods (including `#visibility_changed?` with `:from` and `:to` keyword arguments).

Changes proposed in this pull request:
* Implement ActiveModel::Dirty for visibility
* Make child gems match parent hydra-head rails version dependencies
* Remove outdated handling of activemodel < 4.2 in unit specs

@samvera/hydra-head
