### PR TITLE
Make child gems match parent hydra-head rails version dependencies

### DIFF
--- a/hydra-access-controls/hydra-access-controls.gemspec
+++ b/hydra-access-controls/hydra-access-controls.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.4'
 
-  gem.add_dependency 'activesupport', '>= 4', '< 7'
+  gem.add_dependency 'activesupport', '>= 5.2', '< 7'
   gem.add_dependency 'active-fedora', '>= 10.0.0'
   gem.add_dependency 'blacklight-access_controls', '~> 6.0'
   gem.add_dependency 'cancancan', '>= 1.8', '< 4'

--- a/hydra-access-controls/spec/unit/embargoable_spec.rb
+++ b/hydra-access-controls/spec/unit/embargoable_spec.rb
@@ -165,11 +165,7 @@ describe Hydra::AccessControls::Embargoable do
     context "when the same embargo is applied" do
       before do
         subject.apply_embargo(future_date.to_s)
-        if ActiveModel.version < Gem::Version.new('4.2.0')
-          subject.embargo.send(:reset_changes)
-        else
-          subject.embargo.send(:clear_changes_information)
-        end
+        subject.embargo.send(:clear_changes_information)
       end
 
       it "doesn't call visibility_will_change!" do
@@ -248,11 +244,7 @@ describe Hydra::AccessControls::Embargoable do
       context "when the same lease is applied" do
         before do
           subject.apply_lease(future_date.to_s)
-          if ActiveModel.version < Gem::Version.new('4.2.0')
-            subject.lease.send(:reset_changes)
-          else
-            subject.lease.send(:clear_changes_information)
-          end
+          subject.lease.send(:clear_changes_information)
         end
 
         it "doesn't call visibility_will_change!" do
@@ -266,11 +258,7 @@ describe Hydra::AccessControls::Embargoable do
       before do
         subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
         # reset the changed log
-        if ActiveModel.version < Gem::Version.new('4.2.0')
-          subject.send(:reset_changes)
-        else
-          subject.send(:clear_changes_information)
-        end
+        subject.send(:clear_changes_information)
       end
 
       it "applies appropriate embargo_visibility settings" do

--- a/hydra-core/hydra-core.gemspec
+++ b/hydra-core/hydra-core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.4'
 
   gem.add_dependency 'hydra-access-controls', version
-  gem.add_dependency "railties", '>= 4.0.0', '< 7'
+  gem.add_dependency "railties", '>= 5.2', '< 7'
 
   gem.add_development_dependency 'rails-controller-testing', '~> 1'
   gem.add_development_dependency 'rspec-rails', '~> 4.0'


### PR DESCRIPTION
This PR clears up inconsistencies between the gemspecs of hydra-head and its two child gems.  While hydra-head depends on rails >=5,2, < 7, both hydra-access-controls and hydra-core allow for rails components as low as 4.0.  This seems like an oversight to me where the two child gems should be made to match hydra-head, but if any application was depending on just a child gem and not hydra-head then this change might necessitate a major version bump.  FWIW all three gems are only tested with rails 5.2 and 6.0 at the moment.

Also removes outdated handling of activemodel < 4.2 in unit specs

@samvera/hydra-head
