### PR TITLE
Bump versions of wrapper gems to ensure engine_cart works locally

### DIFF
--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'engine_cart', '~> 2.2'
   s.add_development_dependency 'factory_bot'
-  s.add_development_dependency 'fcrepo_wrapper', '~> 0.6'
+  s.add_development_dependency 'fcrepo_wrapper', '~> 0.9'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'solr_wrapper', '~> 0.18'
+  s.add_development_dependency 'solr_wrapper', '~> 2.2'
   s.add_development_dependency 'rspec_junit_formatter'
 end


### PR DESCRIPTION
When working on #514, I ran into issues generating a test app which was resolved by bumping the versions of these two gems.

@samvera/hydra-head
