### PR TITLE
Ensuring embargo/lease changes are persisted (backport)

### DIFF
--- a/hydra-access-controls/app/models/concerns/hydra/access_controls/embargoable.rb
+++ b/hydra-access-controls/app/models/concerns/hydra/access_controls/embargoable.rb
@@ -8,8 +8,8 @@ module Hydra
         validates :lease_expiration_date, :'hydra/future_date' => true, if: :enforce_future_date_for_lease?
         validates :embargo_release_date, :'hydra/future_date' => true, if: :enforce_future_date_for_embargo?
 
-        belongs_to :embargo, predicate: Hydra::ACL.hasEmbargo, class_name: 'Hydra::AccessControls::Embargo'
-        belongs_to :lease, predicate: Hydra::ACL.hasLease, class_name: 'Hydra::AccessControls::Lease'
+        belongs_to :embargo, predicate: Hydra::ACL.hasEmbargo, class_name: 'Hydra::AccessControls::Embargo', autosave: true
+        belongs_to :lease, predicate: Hydra::ACL.hasLease, class_name: 'Hydra::AccessControls::Lease', autosave: true
 
         delegate :visibility_during_embargo, :visibility_during_embargo=, :visibility_after_embargo, :visibility_after_embargo=, :embargo_release_date, :embargo_release_date=, :embargo_history, :embargo_history=, to: :existing_or_new_embargo
         delegate :visibility_during_lease, :visibility_during_lease=, :visibility_after_lease, :visibility_after_lease=, :lease_expiration_date, :lease_expiration_date=, :lease_history, :lease_history=, to: :existing_or_new_lease


### PR DESCRIPTION
Prior to this commit, when a user changed the Embargo or Lease of an
already persisted object, that change was not persisted.

With this commit, those changes are persisted.

Related to samvera/hyrax#4537
Related to samvera/hyrax#4534

@samvera/hydra-head
