### PR TITLE
Rails 6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,10 @@ workflows:
   ci:
     jobs:
       - bundle_and_test:
+          name: "ruby2-7_rails6.0"
+          ruby_version: 2.7.0
+          rails_version: 6.0.3.4
+      - bundle_and_test:
           name: "ruby2-7_rails5.2"
           ruby_version: 2.7.0
           rails_version: 5.2.4.4

--- a/hydra-access-controls/lib/hydra-access-controls.rb
+++ b/hydra-access-controls/lib/hydra-access-controls.rb
@@ -29,7 +29,13 @@ module Hydra
     alias :config :configure
   end
 
-  class Engine < Rails::Engine; end
+  class Engine < Rails::Engine
+    config.before_configuration do
+      ActiveSupport::Inflector.inflections(:en) do |inflect|
+        inflect.acronym 'ACL'
+      end
+    end
+  end
 
   # This error is raised when a user isn't allowed to access a given controller action.
   # This usually happens within a call to AccessControlsEnforcement#enforce_access_controls but can be

--- a/hydra-access-controls/spec/factories/objects.rb
+++ b/hydra-access-controls/spec/factories/objects.rb
@@ -1,0 +1,34 @@
+FactoryBot.define do
+
+  #
+  # Repository Objects
+  #
+
+  factory :asset, :class => ModsAsset do |o|
+  end
+
+  factory :admin_policy, :class => Hydra::AdminPolicy do |o|
+  end
+
+  factory :default_access_asset, :parent=>:asset do |a|
+    permissions_attributes { [{ name: "joe_creator", access: "edit", type: "person" }] }
+  end
+
+  factory :dept_access_asset, :parent=>:asset do |a|
+    permissions_attributes { [{ name: "africana-faculty", access: "read", type: "group" }, { name: "joe_creator", access: "edit", type: "person" }] }
+  end
+
+  factory :group_edit_asset, :parent=>:asset do |a|
+    permissions_attributes { [{ name:"africana-faculty", access: "edit", type: "group" }, {name: "calvin_collaborator", access: "edit", type: "person"}] }
+  end
+
+  factory :org_read_access_asset, :parent=>:asset do |a|
+    permissions_attributes { [{ name: "registered", access: "read", type: "group" }, { name: "joe_creator", access: "edit", type: "person" }, { name: "calvin_collaborator", access: "edit", type: "person" }] }
+  end
+
+  factory :open_access_asset, :parent=>:asset do |a|
+    permissions_attributes { [{ name: "public", access: "read", type: "group" }, { name: "joe_creator", access: "edit", type: "person" }, { name: "calvin_collaborator", access: "edit", type: "person" }] }
+  end
+
+end
+

--- a/hydra-access-controls/spec/factories/user.rb
+++ b/hydra-access-controls/spec/factories/user.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
 
   # Users
-
   # Prototype user factory
   factory :user, :aliases => [:owner] do |u|
     sequence :uid do |n|
@@ -58,36 +57,5 @@ FactoryBot.define do
     uid { 'alice_admin' }
     password { 'alice_admin' }
   end
-
-  #
-  # Repository Objects
-  #
-
-  factory :asset, :class => ModsAsset do |o|
-  end
-
-  factory :admin_policy, :class => Hydra::AdminPolicy do |o|
-  end
-
-  factory :default_access_asset, :parent=>:asset do |a|
-    permissions_attributes { [{ name: "joe_creator", access: "edit", type: "person" }] }
-  end
-
-  factory :dept_access_asset, :parent=>:asset do |a|
-    permissions_attributes { [{ name: "africana-faculty", access: "read", type: "group" }, { name: "joe_creator", access: "edit", type: "person" }] }
-  end
-
-  factory :group_edit_asset, :parent=>:asset do |a|
-    permissions_attributes { [{ name:"africana-faculty", access: "edit", type: "group" }, {name: "calvin_collaborator", access: "edit", type: "person"}] }
-  end
-
-  factory :org_read_access_asset, :parent=>:asset do |a|
-    permissions_attributes { [{ name: "registered", access: "read", type: "group" }, { name: "joe_creator", access: "edit", type: "person" }, { name: "calvin_collaborator", access: "edit", type: "person" }] }
-  end
-
-  factory :open_access_asset, :parent=>:asset do |a|
-    permissions_attributes { [{ name: "public", access: "read", type: "group" }, { name: "joe_creator", access: "edit", type: "person" }, { name: "calvin_collaborator", access: "edit", type: "person" }] }
-  end
-
 end
 

--- a/hydra-access-controls/spec/spec_helper.rb
+++ b/hydra-access-controls/spec/spec_helper.rb
@@ -48,7 +48,8 @@ require "support/user"
 require "factory_bot"
 require 'rspec/mocks'
 require 'rspec/its'
-require "factories"
+require 'factories/user'
+require 'factories/objects'
 
 # HttpLogger.logger = Logger.new(STDOUT)
 # HttpLogger.ignore = [/localhost:8983\/solr/]

--- a/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
+++ b/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
@@ -80,7 +80,9 @@ module Hydra
       # Override this if you'd like a different filename
       # @return [String] the filename
       def file_name
-        params[:filename] || file.original_name || (asset.respond_to?(:label) && asset.label) || file.id
+        fname = params[:filename] || file.original_name || (asset.respond_to?(:label) && asset.label) || file.id
+        fname = URI.unescape(fname) if Rails.version >= '6.0'
+        fname
       end
 
 

--- a/hydra-core/spec/controllers/catalog_controller_spec.rb
+++ b/hydra-core/spec/controllers/catalog_controller_spec.rb
@@ -79,7 +79,7 @@ describe CatalogController do
         it "is able to negotiate jsonld" do
           get 'show', params: { id: asset.id, format: :jsonld }
 
-          expect(response).to be_success
+          expect(response).to be_successful
           expect(response.headers['Content-Type']).to include("application/ld+json")
           graph = RDF::Reader.for(:jsonld).new(response.body)
           expect(graph.statements.to_a.length).to eq 3
@@ -88,7 +88,7 @@ describe CatalogController do
         it "is able to negotiate ttl" do
           get 'show', params: { id: asset.id, format: :ttl }
 
-          expect(response).to be_success
+          expect(response).to be_successful
           graph = RDF::Reader.for(:ttl).new(response.body)
           expect(graph.statements.to_a.length).to eq 3
         end

--- a/hydra-core/spec/controllers/downloads_controller_spec.rb
+++ b/hydra-core/spec/controllers/downloads_controller_spec.rb
@@ -76,7 +76,7 @@ describe DownloadsController do
           get :show, params: { id: obj }
           expect(response).to be_successful
           expect(response.headers['Content-Type']).to start_with "image/png"
-          expect(response.headers["Content-Disposition"]).to eq "inline; filename=\"buzz.png\""
+          expect(response.headers["Content-Disposition"]).to start_with "inline; filename=\"buzz.png\""
           expect(response.body).to eq 'fizz'
         end
 
@@ -85,7 +85,7 @@ describe DownloadsController do
           get :show, params: { id: obj }
           expect(response).to be_successful
           expect(response.headers['Content-Type']).to start_with "image/png"
-          expect(response.headers["Content-Disposition"]).to eq "inline; filename=\"world.png\""
+          expect(response.headers["Content-Disposition"]).to start_with "inline; filename=\"world.png\""
           expect(response.body).to eq 'foobarfoobarfoobar'
         end
 
@@ -101,7 +101,7 @@ describe DownloadsController do
               get :show, params: { id: obj, file: "descMetadata" }
               expect(response).to be_successful
               expect(response.headers['Content-Type']).to start_with "text/plain"
-              expect(response.headers["Content-Disposition"]).to eq "inline; filename=\"metadata.xml\""
+              expect(response.headers["Content-Disposition"]).to start_with "inline; filename=\"metadata.xml\""
               expect(response.body).to eq "It's a stream"
             end
           end
@@ -111,7 +111,7 @@ describe DownloadsController do
           get :show, params: { id: obj, disposition: "inline" }
           expect(response).to be_successful
           expect(response.headers['Content-Type']).to start_with "image/png"
-          expect(response.headers["Content-Disposition"]).to eq "inline; filename=\"world.png\""
+          expect(response.headers["Content-Disposition"]).to start_with "inline; filename=\"world.png\""
           expect(response.body).to eq 'foobarfoobarfoobar'
         end
 
@@ -119,7 +119,8 @@ describe DownloadsController do
           get :show, params: { id: obj, "filename" => "my%20dog.png" }
           expect(response).to be_successful
           expect(response.headers['Content-Type']).to start_with "image/png"
-          expect(response.headers["Content-Disposition"]).to eq "inline; filename=\"my%20dog.png\""
+          expect(response.headers["Content-Disposition"]).to start_with "inline; filename="
+          expect(response.headers["Content-Disposition"]).to include "my%20dog.png"
           expect(response.body).to eq 'foobarfoobarfoobar'
         end
       end
@@ -148,7 +149,7 @@ describe DownloadsController do
           expect(response.headers["Content-Length"]).to eq '16'
           expect(response.headers['Accept-Ranges']).to eq 'bytes'
           expect(response.headers['Content-Type']).to start_with "video/webm"
-          expect(response.headers["Content-Disposition"]).to eq "inline; filename=\"MyVideo.webm\""
+          expect(response.headers["Content-Disposition"]).to start_with "inline; filename=\"MyVideo.webm\""
           expect(response.status).to eq 206
         end
 

--- a/hydra-core/spec/spec_helper.rb
+++ b/hydra-core/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'hydra-core'
 
 require 'simplecov'
 require 'coveralls'
+require 'rails-controller-testing'
 
 SimpleCov.root(File.expand_path('../..', __dir__))
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
@@ -29,6 +30,9 @@ ActiveFedora::Base.logger = Logger.new(STDOUT)
 require 'active_fedora/cleaner'
 RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include ::Rails::Controller::Testing::TemplateAssertions, type: :controller
+  config.include ::Rails::Controller::Testing::TestProcess, type: :controller
+  config.include ::Rails::Controller::Testing::Integration, type: :controller
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
 

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'engine_cart', '~> 2.2'
   s.add_development_dependency 'factory_bot'
+  s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'fcrepo_wrapper', '~> 0.6'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'simplecov'

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'solr_wrapper', '~> 2.0'
   s.add_development_dependency 'rspec_junit_formatter'
+  s.add_development_dependency 'rails-controller-testing'
 end


### PR DESCRIPTION
Changes proposed in this pull request:
* Unescape filenames in content-disposition for rails 6 to maintain current behavior and avoid double encoding (See https://github.com/rails/rails/pull/33829)
* Add ACL acronym instead of depending on it already existing
* Refactor factories so they can load under rails 6
* Add factory_bot_rails as a dev dependency
* Make tests compatible with rails 6 

@samvera/hydra-head
