### PR TITLE
Uri escape

### DIFF
--- a/hydra-access-controls/app/models/hydra/access_controls/permission.rb
+++ b/hydra-access-controls/app/models/hydra/access_controls/permission.rb
@@ -1,11 +1,7 @@
 module Hydra::AccessControls
-  AGENT_URL_SCHEME = 'http'.freeze
-  AGENT_URL_HOST = 'projecthydra.org'.freeze
-  GROUP_AGENT_PATH = '/ns/auth/group'.freeze
-  PERSON_AGENT_PATH = '/ns/auth/person'.freeze
   AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/'.freeze
-  GROUP_AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/group'.freeze # This is currently only used in the context of testing this code
-  PERSON_AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/person'.freeze # This is currently only used in the context of testing this code
+  GROUP_AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/group'.freeze
+  PERSON_AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/person'.freeze
   class Permission < AccessControlList
     has_many :admin_policies, inverse_of: :default_permissions, class_name: 'Hydra::AdminPolicy'
 
@@ -75,9 +71,9 @@ module Hydra::AccessControls
       raise "Can't build agent #{inspect}" unless name && type
       self.agent = case type
                    when 'group'
-                     build_agent_resource(GROUP_AGENT_PATH, name)
+                     build_agent_resource(GROUP_AGENT_URL_PREFIX, name)
                    when 'person'
-                     build_agent_resource(PERSON_AGENT_PATH, name)
+                     build_agent_resource(PERSON_AGENT_URL_PREFIX, name)
                    else
                      raise ArgumentError, "Unknown agent type #{type.inspect}"
                    end
@@ -86,12 +82,8 @@ module Hydra::AccessControls
     # The current URL.hash standard (As of March 2021) is that the post-hash portion of the URL is not percent-decoded
     # however in order to ensure backward compatibility with already recorded values we are normalizing
     # the fragment here. See https://developer.mozilla.org/en-US/docs/Web/API/URL/hash
-    def build_agent_rdf(path, name)
-      ::RDF::URI.new(scheme: AGENT_URL_SCHEME, host: AGENT_URL_HOST, path: path, fragment: name).normalize!
-    end
-
-    def build_agent_resource(path, name)
-      [Agent.new(build_agent_rdf(path, name))]
+    def build_agent_resource(prefix, name)
+      [Agent.new(::RDF::URI.new("#{prefix}##{URI.encode(name)}").normalize!)]
     end
 
     def build_access(access)

--- a/hydra-access-controls/app/models/hydra/access_controls/permission.rb
+++ b/hydra-access-controls/app/models/hydra/access_controls/permission.rb
@@ -5,8 +5,15 @@ module Hydra::AccessControls
   GROUP_AGENT_PATH = '/ns/auth/group'.freeze
   PERSON_AGENT_PATH = '/ns/auth/person'.freeze
   AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/'.freeze
-  GROUP_AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/group'.freeze
-  PERSON_AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/person'.freeze
+
+  GroupAgentUrlPrefix = Exception.new("GROUP_AGENT_URL_PREFIX is deprecated and being replaced by the individual portions of the url, AGENT_URL_SCHEME, AGENT_URL_HOST, and GROUP_AGENT_PATH")
+  GROUP_AGENT_URL_PREFIX = GroupAgentUrlPrefix # previous version used this name, superceded by individual url components
+  PersonAgentUrlPrefix = Exception.new("PERSON_AGENT_URL_PREFIX is deprecated and being replaced by the individual portions of the url, AGENT_URL_SCHEME, AGENT_URL_HOST, and PERSON_AGENT_PATH")
+  PERSON_AGENT_URL_PREFIX = PersonAgentUrlPrefix
+
+  deprecate_constant :GROUP_AGENT_URL_PREFIX
+  deprecate_constant :PERSON_AGENT_URL_PREFIX
+
   class Permission < AccessControlList
     has_many :admin_policies, inverse_of: :default_permissions, class_name: 'Hydra::AdminPolicy'
 

--- a/hydra-access-controls/app/models/hydra/access_controls/permission.rb
+++ b/hydra-access-controls/app/models/hydra/access_controls/permission.rb
@@ -5,15 +5,8 @@ module Hydra::AccessControls
   GROUP_AGENT_PATH = '/ns/auth/group'.freeze
   PERSON_AGENT_PATH = '/ns/auth/person'.freeze
   AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/'.freeze
-
-  GroupAgentUrlPrefix = Exception.new("GROUP_AGENT_URL_PREFIX is deprecated and being replaced by the individual portions of the url, AGENT_URL_SCHEME, AGENT_URL_HOST, and GROUP_AGENT_PATH")
-  GROUP_AGENT_URL_PREFIX = GroupAgentUrlPrefix # previous version used this name, superceded by individual url components
-  PersonAgentUrlPrefix = Exception.new("PERSON_AGENT_URL_PREFIX is deprecated and being replaced by the individual portions of the url, AGENT_URL_SCHEME, AGENT_URL_HOST, and PERSON_AGENT_PATH")
-  PERSON_AGENT_URL_PREFIX = PersonAgentUrlPrefix
-
-  deprecate_constant :GROUP_AGENT_URL_PREFIX
-  deprecate_constant :PERSON_AGENT_URL_PREFIX
-
+  GROUP_AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/group'.freeze
+  PERSON_AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/person'.freeze
   class Permission < AccessControlList
     has_many :admin_policies, inverse_of: :default_permissions, class_name: 'Hydra::AdminPolicy'
 

--- a/hydra-access-controls/app/models/hydra/access_controls/permission.rb
+++ b/hydra-access-controls/app/models/hydra/access_controls/permission.rb
@@ -41,7 +41,7 @@ module Hydra::AccessControls
     end
 
     def agent_name
-      URI.decode(parsed_agent.last)
+      URI.decode_www_form_component(parsed_agent.last)
     end
 
     def update(*)
@@ -80,7 +80,7 @@ module Hydra::AccessControls
     end
 
     def build_agent_resource(prefix, name)
-      [Agent.new(::RDF::URI.new("#{prefix}##{URI.encode(name)}"))]
+      [Agent.new(::RDF::URI.new("#{prefix}##{ERB::Util.url_encode(name)}"))]
     end
 
     def build_access(access)

--- a/hydra-access-controls/app/models/hydra/access_controls/permission.rb
+++ b/hydra-access-controls/app/models/hydra/access_controls/permission.rb
@@ -1,12 +1,11 @@
 module Hydra::AccessControls
   AGENT_URL_SCHEME = 'http'.freeze
   AGENT_URL_HOST = 'projecthydra.org'.freeze
-  AGENT_URL_PATH = '/ns/auth/'.freeze
   GROUP_AGENT_PATH = '/ns/auth/group'.freeze
   PERSON_AGENT_PATH = '/ns/auth/person'.freeze
   AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/'.freeze
-  GROUP_AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/group'.freeze
-  PERSON_AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/person'.freeze
+  GROUP_AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/group'.freeze # This is currently only used in the context of testing this code
+  PERSON_AGENT_URL_PREFIX = 'http://projecthydra.org/ns/auth/person'.freeze # This is currently only used in the context of testing this code
   class Permission < AccessControlList
     has_many :admin_policies, inverse_of: :default_permissions, class_name: 'Hydra::AdminPolicy'
 

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'hydra-access-controls', version
   s.add_dependency 'hydra-core', version
-  s.add_dependency 'rails', '>= 5.2', '< 6.1'
+  s.add_dependency 'rails', '>= 5.2.4', '< 6.1'
 
   s.add_development_dependency 'coveralls'
-  s.add_development_dependency 'engine_cart', '~> 2.2'
+  s.add_development_dependency 'engine_cart', '~> 2.2.0'
   s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'fcrepo_wrapper', '~> 0.6'
   s.add_development_dependency 'rspec-rails'

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 5.2.4', '< 6.1'
 
   s.add_development_dependency 'coveralls'
-  s.add_development_dependency 'engine_cart', '~> 2.2.0'
+  s.add_development_dependency 'engine_cart', '~> 2.2'
   s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'fcrepo_wrapper', '~> 0.9'
   s.add_development_dependency 'rspec-rails'

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'engine_cart', '~> 2.2.0'
   s.add_development_dependency 'factory_bot'
-  s.add_development_dependency 'fcrepo_wrapper', '~> 0.6'
+  s.add_development_dependency 'fcrepo_wrapper', '~> 0.9'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'solr_wrapper', '~> 0.18'
+  s.add_development_dependency 'solr_wrapper', '~> 3'
   s.add_development_dependency 'rspec_junit_formatter'
 end


### PR DESCRIPTION
Address deprecated URI.escape method and related methods. In applications using Ruby 2.7 and above this deprecation now creates a warning-level message which clogs up logs and makes it hard to diagnose issues with Hydra::AccessControls. 

Changes proposed in this pull request:
* Build the RDF::URI by giving the broken-down portions of the URI, rather than giving it the entire thing as a string. This allows the RDF gem to use the appropriate escaping for the various portions of the URI, and it can then recognize and re-normalize the "fragment" portion of the URI. From what I'm seeing, the standard is currently that the "fragment" portion of the URI, also referred to as the URL.hash, should not be percent-decoded; however, we are continuing to do so in order to ensure consistent data. 
  * I would like feedback on whether the way I have broken out the global variables is likely to break things for people who may have overridden the global variables - is there a better way to do this? Is overriding them a thing people are likely to have done? Would it be better to take the existing globals and break them down in to scheme, host, path, and prefix, and re-build the RDF::URI from there?
* Engine-cart requires Rails 5.2.4 or above, update dependency
* Update solr_wrapper and fcrepo_wrapper development dependencies in order to allow for local testing


@samvera/hydra-head
