### PR TITLE
Return actual gem dependency to prior

### DIFF
--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'hydra-access-controls', version
   s.add_dependency 'hydra-core', version
-  s.add_dependency 'rails', '>= 5.2.4', '< 6.1'
+  s.add_dependency 'rails', '>= 5.2', '< 6.1'
 
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'engine_cart', '~> 2.2'


### PR DESCRIPTION
Previous merged PR upgraded the Rails dependency on the 11.x branch, this PR reverts this change in order to allow for a patch-level release of the URI deprecation fix. 

See [Instructions for
Contributors](http://github.com/samvera/hydra-head/wiki/For-Contributors) for how to address dependencies with Engine Cart in development.