### PR TITLE
Take URI.escape back out

### DIFF
--- a/hydra-access-controls/app/models/hydra/access_controls/permission.rb
+++ b/hydra-access-controls/app/models/hydra/access_controls/permission.rb
@@ -83,7 +83,7 @@ module Hydra::AccessControls
     # however in order to ensure backward compatibility with already recorded values we are normalizing
     # the fragment here. See https://developer.mozilla.org/en-US/docs/Web/API/URL/hash
     def build_agent_resource(prefix, name)
-      [Agent.new(::RDF::URI.new("#{prefix}##{URI.encode(name)}").normalize!)]
+      [Agent.new(::RDF::URI.new("#{prefix}##{name}").normalize!)]
     end
 
     def build_access(access)


### PR DESCRIPTION
The previous fix for the URI.escape deprecation accidentally left in one instance of it (see https://github.com/samvera/hydra-head/pull/525), probably due to a commit confusion. This takes it out and should solve the issue for this gem once and for all. 

@samvera/hydra-head
