### PR TITLE
Upgrade to rails 5.2.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,16 +59,16 @@ workflows:
       - bundle_and_test:
           name: "ruby2-7_rails5.2"
           ruby_version: 2.7.0
-          rails_version: 5.2.4.1
+          rails_version: 5.2.5
       - bundle_and_test:
           name: "ruby2-6_rails5.2"
           ruby_version: 2.6.3
-          rails_version: 5.2.4.1
+          rails_version: 5.2.5
       - bundle_and_test:
           name: "ruby2-5_rails5.2"
           ruby_version: 2.5.5
-          rails_version: 5.2.4.1
+          rails_version: 5.2.5
       - bundle_and_test:
           name: "ruby2-4_rails5.2"
           ruby_version: 2.4.6
-          rails_version: 5.2.4.1
+          rails_version: 5.2.5

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'hydra-access-controls', version
   s.add_dependency 'hydra-core', version
-  s.add_dependency 'rails', '>= 5.2', '< 6.1'
+  s.add_dependency 'rails', '>= 5.2.5', '< 6.1'
 
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'engine_cart', '~> 2.2'


### PR DESCRIPTION
This appears to fix the engine_cart build probably due to the upgrade of
marcel and dropping the dependency on mimemagic.
I had to manually downgrade sprockets and rerun `rake ci` due to
sprockets 4.0.2 being incompatible with another dependency.

@samvera/hydra-head
