### PR TITLE
Revert URI.escape and URI.unescape changes

### DIFF
--- a/hydra-access-controls/app/models/hydra/access_controls/permission.rb
+++ b/hydra-access-controls/app/models/hydra/access_controls/permission.rb
@@ -83,7 +83,7 @@ module Hydra::AccessControls
     # however in order to ensure backward compatibility with already recorded values we are normalizing
     # the fragment here. See https://developer.mozilla.org/en-US/docs/Web/API/URL/hash
     def build_agent_resource(prefix, name)
-      [Agent.new(::RDF::URI.new("#{prefix}##{name}").normalize!)]
+      [Agent.new(::RDF::URI.new("#{prefix}##{URI.encode(name)}").normalize!)]
     end
 
     def build_access(access)

--- a/hydra-access-controls/app/models/hydra/access_controls/permission.rb
+++ b/hydra-access-controls/app/models/hydra/access_controls/permission.rb
@@ -41,7 +41,7 @@ module Hydra::AccessControls
     end
 
     def agent_name
-      URI.decode_www_form_component(parsed_agent.last)
+      URI.decode(parsed_agent.last)
     end
 
     def update(*)
@@ -79,11 +79,8 @@ module Hydra::AccessControls
                    end
     end
 
-    # The current URL.hash standard (As of March 2021) is that the post-hash portion of the URL is not percent-decoded
-    # however in order to ensure backward compatibility with already recorded values we are normalizing
-    # the fragment here. See https://developer.mozilla.org/en-US/docs/Web/API/URL/hash
     def build_agent_resource(prefix, name)
-      [Agent.new(::RDF::URI.new("#{prefix}##{URI.encode(name)}").normalize!)]
+      [Agent.new(::RDF::URI.new("#{prefix}##{URI.encode(name)}"))]
     end
 
     def build_access(access)

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'engine_cart', '~> 2.2'
   s.add_development_dependency 'factory_bot'
-  s.add_development_dependency 'fcrepo_wrapper', '~> 0.9'
+  s.add_development_dependency 'fcrepo_wrapper', '~> 0.6'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'solr_wrapper', '~> 3'
+  s.add_development_dependency 'solr_wrapper', '~> 0.18'
   s.add_development_dependency 'rspec_junit_formatter'
 end


### PR DESCRIPTION
Revert changes made to avoid deprecation warnings for URI.escape and URI.unescape.  Later testing showed that while the test suite passed without modification there are some scenarios that weren't being tested that had changes in how they encoded.  The existing test is for spaces which behave the same as they did before but agent names (group names or email addresses) with a `+` or `%20` changed behavior and are now encoding the same as spaces.  This is a collision which could be problematic as you can see below.  Each of the three examples for both group and user are unique and possible but end up getting the same stored value.

As discussed on the tech call the proposed course of action is to merge this revertion, cut a new patch release (11.0.6), and yank 11.0.5 and 11.0.4.  This change only affects the 11.x line as the changes hadn't been forward ported to the main branch yet.

Prior behavior 11.0.1:
>(byebug) described_class.new(type: 'group', name: 'hydra%20devs', access: 'read').agent.first.rdf_subject.to_s
/home/cjcolvar/Code/samvera/hydra-head-old/hydra-access-controls/app/models/hydra/access_controls/permission.rb:83: warning: URI.escape is obsolete
"http://projecthydra.org/ns/auth/group#hydra%2520devs"
(byebug) described_class.new(type: 'group', name: 'hydra+devs', access: 'read').agent.first.rdf_subject.to_s
/home/cjcolvar/Code/samvera/hydra-head-old/hydra-access-controls/app/models/hydra/access_controls/permission.rb:83: warning: URI.escape is obsolete
"http://projecthydra.org/ns/auth/group#hydra+devs"
(byebug) described_class.new(type: 'group', name: 'hydra devs', access: 'read').agent.first.rdf_subject.to_s
/home/cjcolvar/Code/samvera/hydra-head-old/hydra-access-controls/app/models/hydra/access_controls/permission.rb:83: warning: URI.escape is obsolete
"http://projecthydra.org/ns/auth/group#hydra%20devs"
(byebug) described_class.new(type: 'person', name: FactoryBot.build(:user, email: 'calvin%20collaborator@gmail.com'), access: 'read').agent.first.rdf_subject.to_s
/home/cjcolvar/Code/samvera/hydra-head-old/hydra-access-controls/app/models/hydra/access_controls/permission.rb:83: warning: URI.escape is obsolete
"http://projecthydra.org/ns/auth/person#calvin%2520collaborator@gmail.com"
(byebug) described_class.new(type: 'person', name: FactoryBot.build(:user, email: 'calvin+collaborator@gmail.com'), access: 'read').agent.first.rdf_subject.to_s
/home/cjcolvar/Code/samvera/hydra-head-old/hydra-access-controls/app/models/hydra/access_controls/permission.rb:83: warning: URI.escape is obsolete
"http://projecthydra.org/ns/auth/person#calvin+collaborator@gmail.com"
(byebug) described_class.new(type: 'person', name: FactoryBot.build(:user, email: 'calvin collaborator@gmail.com'), access: 'read').agent.first.rdf_subject.to_s
/home/cjcolvar/Code/samvera/hydra-head-old/hydra-access-controls/app/models/hydra/access_controls/permission.rb:83: warning: URI.escape is obsolete
"http://projecthydra.org/ns/auth/person#calvin%20collaborator@gmail.com"

Behavior in 11.0.5:
>(byebug) described_class.new(type: 'group', name: 'hydra%20devs', access: 'read').agent.first.rdf_subject.to_s
"http://projecthydra.org/ns/auth/group#hydra%20devs"
(byebug) described_class.new(type: 'group', name: 'hydra+devs', access: 'read').agent.first.rdf_subject.to_s
"http://projecthydra.org/ns/auth/group#hydra%20devs"
(byebug) described_class.new(type: 'group', name: 'hydra devs', access: 'read').agent.first.rdf_subject.to_s
"http://projecthydra.org/ns/auth/group#hydra%20devs"
(byebug) described_class.new(type: 'person', name: FactoryBot.build(:user, email: 'calvin%20collaborator@gmail.com'), access: 'read').agent.first.rdf_subject.to_s
"http://projecthydra.org/ns/auth/person#calvin%20collaborator@gmail.com"
(byebug) described_class.new(type: 'person', name: FactoryBot.build(:user, email: 'calvin+collaborator@gmail.com'), access: 'read').agent.first.rdf_subject.to_s
"http://projecthydra.org/ns/auth/person#calvin%20collaborator@gmail.com"
(byebug) described_class.new(type: 'person', name: FactoryBot.build(:user, email: 'calvin collaborator@gmail.com'), access: 'read').agent.first.rdf_subject.to_s
"http://projecthydra.org/ns/auth/person#calvin%20collaborator@gmail.com"

@samvera/hydra-head
