### PR TITLE
limit embargo/lease date validation to create

### DIFF
--- a/hydra-access-controls/app/models/concerns/hydra/access_controls/embargoable.rb
+++ b/hydra-access-controls/app/models/concerns/hydra/access_controls/embargoable.rb
@@ -5,8 +5,8 @@ module Hydra
       include Hydra::AccessControls::WithAccessRight
 
       included do
-        validates :lease_expiration_date, :'hydra/future_date' => true, if: :enforce_future_date_for_lease?
-        validates :embargo_release_date, :'hydra/future_date' => true, if: :enforce_future_date_for_embargo?
+        validates :lease_expiration_date, :'hydra/future_date' => true, if: :enforce_future_date_for_lease?, on: :create
+        validates :embargo_release_date, :'hydra/future_date' => true, if: :enforce_future_date_for_embargo?, on: :create
 
         belongs_to :embargo, predicate: Hydra::ACL.hasEmbargo, class_name: 'Hydra::AccessControls::Embargo', autosave: true
         belongs_to :lease, predicate: Hydra::ACL.hasLease, class_name: 'Hydra::AccessControls::Lease', autosave: true

--- a/hydra-access-controls/spec/unit/embargoable_spec.rb
+++ b/hydra-access-controls/spec/unit/embargoable_spec.rb
@@ -83,9 +83,9 @@ describe Hydra::AccessControls::Embargoable do
   end
 
   describe 'validations' do
-    context "with dates" do
+    context "with past dates" do
       subject { ModsAsset.new(lease_expiration_date: past_date, embargo_release_date: past_date) }
-      it "validates embargo_release_date and lease_expiration_date" do
+      it "validates embargo_release_date and lease_expiration_date on create" do
         expect(subject).to_not be_valid
         expect(subject.errors[:lease_expiration_date]).to eq ['Must be a future date']
         expect(subject.errors[:embargo_release_date]).to eq ['Must be a future date']


### PR DESCRIPTION
it should be possible to maintain existing embargo/lease data even after the
release date has passed. validating future dates on all saves prevents this;
only do this on `:create` actions instead.

Backport of #533 

@samvera/hydra-head
