### PR TITLE
Updating the CircleCI configuration to check for a master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,15 @@ jobs:
       BLACKLIGHT_VERSION: << parameters.blacklight_version >>
     steps:
       - samvera/cached_checkout
-
+      - run:
+          name: Check for a branch named 'master'
+          command: |
+            git fetch --all --quiet --prune --prune-tags
+            if [[ -n "$(git branch --all --list master */master)" ]]; then
+              echo "A branch named 'master' was found. Please remove it."
+              echo "$(git branch --all --list master */master)"
+            fi
+            [[ -z "$(git branch --all --list master */master)" ]]
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>


### PR DESCRIPTION
Fixes #538 

This PR adds the Circle CI step that fails if the branch name is master.