### PR TITLE
Provide an exact path for render_404.

### DIFF
--- a/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
+++ b/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
@@ -21,7 +21,7 @@ module Hydra
 
       def render_404
         respond_to do |format|
-          format.html { render :file => "#{Rails.root}/public/404", :layout => false, :status => :not_found }
+          format.html { render :file => Rails.root.join("public", "404.html"), :layout => false, :status => :not_found }
           format.any  { head :not_found }
         end
       end


### PR DESCRIPTION
Not providing .html is deprecated in Rails 6.0, doesn't work in 6.1.