### PR TITLE
Issue 557 - Assume client is requesting whole file if no range specified

### DIFF
--- a/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
+++ b/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb
@@ -95,6 +95,8 @@ module Hydra
       # render an HTTP Range response
       def send_range
         _, range = request.headers['HTTP_RANGE'].split('bytes=')
+        # assume client is requesting whole file if no range specified
+        range = '0-' if range.nil?
         from, to = range.split('-').map(&:to_i)
         to = file.size - 1 unless to
         length = to - from + 1


### PR DESCRIPTION
https://github.com/samvera/hydra-head/issues/557

If no range is specified for the Range header, then assume the whole file is being requested by overriding the range value to `"0-"`. This prevents a error that we get frequently in our logs when clients provide the "Range: bytes=" header on their download requests.

@samvera/hydra-head
