### PR TITLE
Test on rails 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
         environment:
           VERBOSE: yes
           SECURITY_JSON: '{"authentication":{"blockUnknown": false, "class":"solr.BasicAuthPlugin", "credentials":{"solr":"IV0EHq1OnNrj6gvRCwvFwTrZ1+z1oBbnQdiVC3otuq0= Ndd7LKvVBAaZIF0QAVi1ekCfAJXr1GGfLtRUXhgrF8c="}, "realm":"My Solr users", "forwardCredentials": false}, "authorization":{ "class":"solr.RuleBasedAuthorizationPlugin", "permissions":[{"name":"security-edit", "role":"admin"}], "user-role":{"solr":"admin"}}}'
+          SOLR_MODULES: "analysis-extras,extraction"
         command: sh -c "server/scripts/cloud-scripts/zkcli.sh -zkhost localhost:2181 -cmd put /security.json \"${SECURITY_JSON}\" && solr-fg -cloud -noprompt  -p << parameters.solr_port >> -z localhost:2181"
 
     working_directory: ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,11 @@ workflows:
   ci:
     jobs:
       - bundle_and_test:
+          name: "ruby3-4_rails8.0"
+          ruby_version: 3.4.4
+          rails_version: 8.0.2
+          active_fedora_version: '>= 15.0.0'
+      - bundle_and_test:
           name: "ruby3-3_rails7.2"
           ruby_version: 3.3.4
           rails_version: 7.2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
       solr_version:
         type: string
         default: "9"
+      additional_engine_cart_options:
+        type: string
+        default: ""
 
     docker:
       - image: cimg/<< parameters.ruby_type >>:<< parameters.ruby_version >>-browsers
@@ -51,7 +54,7 @@ jobs:
     working_directory: ~/project
 
     environment:
-      ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-bundle --skip-listen --skip-spring --skip-yarn --skip-keeps --skip-coffee --skip-puma --skip-test
+      ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-bundle --skip-listen --skip-spring --skip-yarn --skip-keeps --skip-coffee --skip-puma --skip-test <<parameters.additional_engine_cart_options >>
       RAILS_VERSION: << parameters.rails_version >>
       SOLR_TEST_PORT: << parameters.solr_port >>
       ACTIVE_FEDORA_VERSION: << parameters.active_fedora_version >>
@@ -107,6 +110,7 @@ workflows:
           rails_version: 8.0.2
           active_fedora_version: '>= 15.0.0'
           blacklight_version: '~> 8'
+          additional_engine_cart_options: "--css=bootstrap"
       - bundle_and_test:
           name: "ruby3-3_rails7.2"
           ruby_version: 3.3.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,44 +113,44 @@ workflows:
           additional_engine_cart_options: "--css=bootstrap"
       - bundle_and_test:
           name: "ruby3-3_rails7.2"
-          ruby_version: 3.3.4
-          rails_version: 7.2.1
+          ruby_version: 3.3.8
+          rails_version: 7.2.2.1
           active_fedora_version: '>= 15.0.0'
       - bundle_and_test:
           name: "ruby3-3_rails7.1"
-          ruby_version: 3.3.4
-          rails_version: 7.1.4
+          ruby_version: 3.3.8
+          rails_version: 7.1.5.1
           active_fedora_version: '>= 15.0.0'
       - bundle_and_test:
           name: "ruby3-2_rails7.1"
-          ruby_version: 3.2.5
-          rails_version: 7.1.4
+          ruby_version: 3.2.8
+          rails_version: 7.1.5.1
           active_fedora_version: '>= 15.0.0'
       - bundle_and_test:
           name: "ruby3-1_rails7.1"
-          ruby_version: 3.1.6
-          rails_version: 7.1.4
+          ruby_version: 3.1.7
+          rails_version: 7.1.5.1
           active_fedora_version: '>= 15.0.0'
       - bundle_and_test:
           name: "ruby3-3_rails7.0"
-          ruby_version: 3.3.4
-          rails_version: 7.0.8.4
+          ruby_version: 3.3.8
+          rails_version: 7.0.8.7
       - bundle_and_test:
           name: "ruby3-2_rails7.0"
-          ruby_version: 3.2.5
-          rails_version: 7.0.8.4
+          ruby_version: 3.2.8
+          rails_version: 7.0.8.7
       - bundle_and_test:
           name: "ruby3-1_rails7.0"
-          ruby_version: 3.1.6
-          rails_version: 7.0.8.4
+          ruby_version: 3.1.7
+          rails_version: 7.0.8.7
       - bundle_and_test:
           name: "ruby3-2_rails6.1"
-          ruby_version: 3.2.5
-          rails_version: 6.1.7.8
+          ruby_version: 3.2.8
+          rails_version: 6.1.7.10
       - bundle_and_test:
           name: "ruby3-1_rails6.1"
-          ruby_version: 3.1.6
-          rails_version: 6.1.7.8
+          ruby_version: 3.1.7
+          rails_version: 6.1.7.10
 
   nightly:
     triggers:
@@ -163,42 +163,49 @@ workflows:
 
     jobs:
       - bundle_and_test:
+          name: "ruby3-4_rails8.0"
+          ruby_version: 3.4.4
+          rails_version: 8.0.2
+          active_fedora_version: '>= 15.0.0'
+          blacklight_version: '~> 8'
+          additional_engine_cart_options: "--css=bootstrap"
+      - bundle_and_test:
           name: "ruby3-3_rails7.2"
-          ruby_version: 3.3.4
-          rails_version: 7.2.1
+          ruby_version: 3.3.8
+          rails_version: 7.2.2.1
           active_fedora_version: '>= 15.0.0'
       - bundle_and_test:
           name: "ruby3-3_rails7.1"
-          ruby_version: 3.3.4
-          rails_version: 7.1.4
+          ruby_version: 3.3.8
+          rails_version: 7.1.5.1
           active_fedora_version: '>= 15.0.0'
       - bundle_and_test:
           name: "ruby3-2_rails7.1"
-          ruby_version: 3.2.5
-          rails_version: 7.1.4
+          ruby_version: 3.2.8
+          rails_version: 7.1.5.1
           active_fedora_version: '>= 15.0.0'
       - bundle_and_test:
           name: "ruby3-1_rails7.1"
-          ruby_version: 3.1.6
-          rails_version: 7.1.4
+          ruby_version: 3.1.7
+          rails_version: 7.1.5.1
           active_fedora_version: '>= 15.0.0'
       - bundle_and_test:
           name: "ruby3-3_rails7.0"
-          ruby_version: 3.3.4
-          rails_version: 7.0.8.4
+          ruby_version: 3.3.8
+          rails_version: 7.0.8.7
       - bundle_and_test:
           name: "ruby3-2_rails7.0"
-          ruby_version: 3.2.5
-          rails_version: 7.0.8.4
+          ruby_version: 3.2.8
+          rails_version: 7.0.8.7
       - bundle_and_test:
           name: "ruby3-1_rails7.0"
-          ruby_version: 3.1.6
-          rails_version: 7.0.8.4
+          ruby_version: 3.1.7
+          rails_version: 7.0.8.7
       - bundle_and_test:
           name: "ruby3-2_rails6.1"
-          ruby_version: 3.2.5
-          rails_version: 6.1.7.8
+          ruby_version: 3.2.8
+          rails_version: 6.1.7.10
       - bundle_and_test:
           name: "ruby3-1_rails6.1"
-          ruby_version: 3.1.6
-          rails_version: 6.1.7.8
+          ruby_version: 3.1.7
+          rails_version: 6.1.7.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
         default: '~> 7'
       bundler_version:
         type: string
-        default: 2.5.18
+        default: '2.6.9'
       rails_version:
         type: string
       solr_port:
@@ -106,6 +106,7 @@ workflows:
           ruby_version: 3.4.4
           rails_version: 8.0.2
           active_fedora_version: '>= 15.0.0'
+          blacklight_version: '~> 8'
       - bundle_and_test:
           name: "ruby3-3_rails7.2"
           ruby_version: 3.3.4

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,14 @@ else
       gem 'rails', ENV['RAILS_VERSION']
     end
   end
+
+  case ENV['RAILS_VERSION']
+  when /^7\.0/
+    # concurrent-ruby 1.3.5 causes Rails versions below 7.1 to break
+    gem 'concurrent-ruby', '1.3.4'
+  when /^6\.[01]/
+    gem 'concurrent-ruby', '1.3.4'
+  end
 end
 # END ENGINE_CART BLOCK
 

--- a/Gemfile
+++ b/Gemfile
@@ -28,26 +28,10 @@ else
       gem 'rails', ENV['RAILS_VERSION']
     end
   end
-
-  case ENV['RAILS_VERSION']
-  when /^5.[12]/
-    gem 'sass-rails', '~> 5.0'
-  when /^4.2/
-    gem 'responders', '~> 2.0'
-    gem 'sass-rails', '>= 5.0'
-    gem 'coffee-rails', '~> 4.1.0'
-  when /^4.[01]/
-    gem 'sass-rails', '< 5.0'
-  end
 end
 # END ENGINE_CART BLOCK
 
 if !ENV['RAILS_VERSION'] || ENV['RAILS_VERSION'] =~ /^6.0/
-  gem 'psych', '< 4'
-end
-
-if !ENV['RAILS_VERSION'] || ENV['RAILS_VERSION'] =~ /^5/
-  gem 'rails-controller-testing'
   gem 'psych', '< 4'
 end
 

--- a/hydra-access-controls/hydra-access-controls.gemspec
+++ b/hydra-access-controls/hydra-access-controls.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 3.1'
 
-  gem.add_dependency 'activesupport', '>= 6.1', '< 8.0'
+  gem.add_dependency 'activesupport', '>= 6.1', '< 8.1'
   gem.add_dependency 'active-fedora', '>= 10.0.0'
   gem.add_dependency 'blacklight-access_controls', '~> 6.0'
   gem.add_dependency 'cancancan', '>= 1.8', '< 4'
   gem.add_dependency 'deprecation', '~> 1.0'
 
   gem.add_development_dependency 'rake', '>= 12.3.3'
-  gem.add_development_dependency 'rspec', '~> 4.0'
+  gem.add_development_dependency 'rspec'
 end

--- a/hydra-core/hydra-core.gemspec
+++ b/hydra-core/hydra-core.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 3.1'
 
   gem.add_dependency 'hydra-access-controls', version
-  gem.add_dependency "railties", '>= 6.1', '< 8.0'
+  gem.add_dependency "railties", '>= 6.1', '< 8.1'
 
-  gem.add_development_dependency 'rails-controller-testing', '~> 1'
-  gem.add_development_dependency 'rspec-rails', '~> 4.0'
-  gem.add_development_dependency 'sqlite3', '~> 1.3'
+  gem.add_development_dependency 'rails-controller-testing'
+  gem.add_development_dependency 'rspec-rails'
+  gem.add_development_dependency 'sqlite3'
 end

--- a/hydra-core/spec/controllers/catalog_controller_spec.rb
+++ b/hydra-core/spec/controllers/catalog_controller_spec.rb
@@ -30,13 +30,13 @@ describe CatalogController do
       it "should only return public documents if role does not have permissions" do
         allow(controller).to receive(:current_user).and_return(nil)
         get :index
-        expect(assigns(:document_list).count).to eq @public_only_results.docs.count
+        expect(assigns(:response).documents.count).to eq @public_only_results.docs.count
       end
 
       it "should return documents if the group names need to be escaped" do
         allow(RoleMapper).to receive(:roles).and_return(["abc/123","cde/567"])
         get :index
-        expect(assigns(:document_list).count).to eq @public_only_results.docs.count
+        expect(assigns(:response).documents.count).to eq @public_only_results.docs.count
       end
     end
   end

--- a/hydra-core/spec/helpers/blacklight_helper_spec.rb
+++ b/hydra-core/spec/helpers/blacklight_helper_spec.rb
@@ -17,19 +17,19 @@ describe BlacklightHelper do
     end
 
     it "changes camel case to underscored lowercase" do
-      expect(helper.document_partial_name('has_model_s' => ["Presentation"])).to eq "presentation"
-      expect(helper.document_partial_name('has_model_s' => ["GenericContent"])).to eq("generic_content")
+      expect(helper.send(:document_partial_name, 'has_model_s' => ["Presentation"])).to eq "presentation"
+      expect(helper.send(:document_partial_name, 'has_model_s' => ["GenericContent"])).to eq("generic_content")
     end
 
     context "with a single valued field" do
       let(:field_name) { 'has_model_s' }
       it "should support single valued fields" do
-        expect(helper.document_partial_name('has_model_s' => "Chicken")).to eq "chicken"
+        expect(helper.send(:document_partial_name, 'has_model_s' => "Chicken")).to eq "chicken"
       end
     end
 
     it "handles periods" do
-      expect(helper.document_partial_name('has_model_s' => ["text.PDF"])).to eq "text_pdf"
+      expect(helper.send(:document_partial_name, 'has_model_s' => ["text.PDF"])).to eq "text_pdf"
     end
   end
 end

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'hydra-access-controls', version
   s.add_dependency 'hydra-core', version
-  s.add_dependency 'rails', '>= 6.1', '< 8.0'
+  s.add_dependency 'rails', '>= 6.1', '< 8.1'
 
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'engine_cart', '~> 2.3'

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -22,13 +22,13 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 6.1', '< 8.1'
 
   s.add_development_dependency 'coveralls'
-  s.add_development_dependency 'engine_cart', '~> 2.3'
+  s.add_development_dependency 'engine_cart', '>= 2.3'
   s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'factory_bot_rails'
-  s.add_development_dependency 'fcrepo_wrapper', '~> 0.9'
+  s.add_development_dependency 'fcrepo_wrapper', '>= 0.9'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'solr_wrapper', '~> 3.1'
+  s.add_development_dependency 'solr_wrapper', '>= 3.1'
   s.add_development_dependency 'rspec_junit_formatter'
   s.add_development_dependency 'rails-controller-testing'
 end

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -4,6 +4,14 @@ if ENV['ACTIVE_FEDORA_VERSION']
   gem 'active-fedora', ENV['ACTIVE_FEDORA_VERSION']
 end
 
+case ENV['RAILS_VERSION']
+when /^7\.0/
+  # concurrent-ruby 1.3.5 causes Rails versions below 7.1 to break
+  gem 'concurrent-ruby', '1.3.4'
+when /^6\.[01]/
+  gem 'concurrent-ruby', '1.3.4'
+end
+
 if !ENV['RAILS_VERSION'] || ENV['RAILS_VERSION'] =~ /^6.0/ || ENV['RAILS_VERSION'] =~ /^5/
   gem 'psych', '< 4'
 end


### PR DESCRIPTION
- Bump rails/railties/activesupport to `< 8.1`
- Add ruby 3.4 / rails 8.0 / Blacklight 8 to circleci config (and update versions of other ruby / rails)
- Fix tests for Blacklight 8 changes
- Remove version restrictions on 3rd party gems
- Remove engine cart setup in Gemfile for older versions of rails (`< 6`)
- Pin concurrent-ruby in Gemfile / internal test app (not in gemspec)
- Add css processor flag to engine cart generation for rails 8
- Setup for solr 9.8+ in testing