### PR TITLE
Adding support for Rails 8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,13 @@ workflows:
   ci:
     jobs:
       - bundle_and_test:
+          name: "ruby3-4_rails8.1"
+          ruby_version: 3.4.4
+          rails_version: 8.1.1
+          active_fedora_version: '>= 15.0.0'
+          blacklight_version: '~> 8'
+          additional_engine_cart_options: "--css=bootstrap"
+      - bundle_and_test:
           name: "ruby3-4_rails8.0"
           ruby_version: 3.4.7
           rails_version: 8.0.4
@@ -135,6 +142,13 @@ workflows:
                 - main
 
     jobs:
+      - bundle_and_test:
+          name: "ruby3-4_rails8.1"
+          ruby_version: 3.4.4
+          rails_version: 8.1.1
+          active_fedora_version: '>= 15.0.0'
+          blacklight_version: '~> 8'
+          additional_engine_cart_options: "--css=bootstrap"
       - bundle_and_test:
           name: "ruby3-4_rails8.0"
           ruby_version: 3.4.7

--- a/hydra-access-controls/hydra-access-controls.gemspec
+++ b/hydra-access-controls/hydra-access-controls.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 3.1'
 
-  gem.add_dependency 'activesupport', '>= 6.1', '< 8.1'
+  gem.add_dependency 'activesupport', '>= 6.1', '< 9'
   gem.add_dependency 'active-fedora', '>= 10.0.0'
   gem.add_dependency 'blacklight-access_controls', '~> 6.0'
   gem.add_dependency 'cancancan', '>= 1.8', '< 4'

--- a/hydra-core/hydra-core.gemspec
+++ b/hydra-core/hydra-core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 3.1'
 
   gem.add_dependency 'hydra-access-controls', version
-  gem.add_dependency "railties", '>= 6.1', '< 8.1'
+  gem.add_dependency "railties", '>= 6.1', '< 9'
 
   gem.add_development_dependency 'rails-controller-testing'
   gem.add_development_dependency 'rspec-rails'

--- a/hydra-head.gemspec
+++ b/hydra-head.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'hydra-access-controls', version
   s.add_dependency 'hydra-core', version
-  s.add_dependency 'rails', '>= 6.1', '< 8.1'
+  s.add_dependency 'rails', '>= 6.1', '< 9'
 
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'engine_cart', '>= 2.3'


### PR DESCRIPTION
Rails 8 with Blacklight 8 in the test matrix currently failing, presumably because [these backports to BL8 haven't been released](https://github.com/projectblacklight/blacklight/pull/3756).